### PR TITLE
feat(api): add risk assessment module

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -13,6 +13,7 @@ on:
       - 'etc/**'
     branches:
       - "main"
+      - "NIST"
 
 concurrency:
   group: benchmark-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - release/**
+      - NIST
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,6 +13,7 @@ on:
       - 'etc/**'
     branches:
       - main
+      - NIST
 
 env:
   CARGO_TERM_COLOR: always

--- a/common/auth/src/permission.rs
+++ b/common/auth/src/permission.rs
@@ -109,6 +109,15 @@ permission! {
         #[strum(serialize = "delete.sbomGroup")]
         DeleteSbomGroup,
 
+        #[strum(serialize = "create.riskAssessment")]
+        CreateRiskAssessment,
+        #[strum(serialize = "read.riskAssessment")]
+        ReadRiskAssessment,
+        #[strum(serialize = "update.riskAssessment")]
+        UpdateRiskAssessment,
+        #[strum(serialize = "delete.riskAssessment")]
+        DeleteRiskAssessment,
+
         #[strum(serialize = "upload.dataset")]
         UploadDataset,
 

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -25,6 +25,7 @@ cpe = { workspace = true }
 csv = { workspace = true }
 flate2 ={ workspace = true }
 futures-util = { workspace = true }
+hex = { workspace = true }
 isx = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/modules/fundamental/src/endpoints.rs
+++ b/modules/fundamental/src/endpoints.rs
@@ -20,7 +20,10 @@ pub fn configure(
     storage: impl Into<DispatchBackend>,
     analysis: AnalysisService,
 ) {
-    let ingestor_service = IngestorService::new(Graph::new(db.clone()), storage, Some(analysis));
+    let storage: DispatchBackend = storage.into();
+
+    let ingestor_service =
+        IngestorService::new(Graph::new(db.clone()), storage.clone(), Some(analysis));
     svc.app_data(web::Data::new(ingestor_service));
 
     crate::advisory::endpoints::configure(svc, db.clone(), config.advisory_upload_limit);
@@ -31,6 +34,7 @@ pub fn configure(
     crate::sbom::endpoints::configure(svc, db.clone(), config.sbom_upload_limit);
     crate::vulnerability::endpoints::configure(svc, db.clone());
     crate::weakness::endpoints::configure(svc, db.clone());
+    crate::risk_assessment::endpoints::configure(svc, db.clone(), storage);
     crate::sbom_group::endpoints::configure(svc, db, config.max_group_name_length);
 }
 

--- a/modules/fundamental/src/lib.rs
+++ b/modules/fundamental/src/lib.rs
@@ -18,6 +18,7 @@ pub mod weakness;
 pub use endpoints::{Config, configure};
 pub use error::Error;
 
+mod risk_assessment;
 mod sbom_group;
 #[cfg(test)]
 pub mod test;

--- a/modules/fundamental/src/risk_assessment/endpoints/mod.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/mod.rs
@@ -1,0 +1,288 @@
+#[cfg(test)]
+mod test;
+
+use super::{model::*, service::RiskAssessmentService};
+use crate::{Error, db::DatabaseExt};
+use actix_web::{HttpRequest, HttpResponse, Responder, delete, get, post, web};
+use futures_util::stream::TryStreamExt;
+use sea_orm::TransactionTrait;
+use serde_json::json;
+use trustify_auth::{
+    CreateRiskAssessment, DeleteRiskAssessment, ReadRiskAssessment, authorizer::Require,
+};
+use trustify_common::{db::Database, hashing::Digests, id::Id};
+use trustify_module_storage::service::{StorageBackend, StorageKey, dispatch::DispatchBackend};
+
+pub fn configure(
+    config: &mut utoipa_actix_web::service_config::ServiceConfig,
+    db: Database,
+    storage: DispatchBackend,
+) {
+    let service = RiskAssessmentService::new();
+
+    config
+        .app_data(web::Data::new(db))
+        .app_data(web::Data::new(service))
+        .app_data(web::Data::new(storage))
+        .service(create)
+        .service(read)
+        .service(list_by_group)
+        .service(delete_assessment)
+        .service(upload_document)
+        .service(download_document)
+        .service(get_results);
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "createRiskAssessment",
+    request_body = CreateRiskAssessmentRequest,
+    responses(
+        (
+            status = 201, description = "Created the risk assessment",
+            body = inline(serde_json::Value),
+            headers(
+                ("location" = String, description = "The relative URL to the created resource")
+            )
+        ),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+    )
+)]
+#[post("/v2/risk-assessment")]
+/// Create a new risk assessment for a group
+async fn create(
+    req: HttpRequest,
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    web::Json(request): web::Json<CreateRiskAssessmentRequest>,
+    _: Require<CreateRiskAssessment>,
+) -> Result<impl Responder, Error> {
+    let id = db
+        .transaction(async |tx| service.create(request, tx).await)
+        .await?;
+
+    Ok(HttpResponse::Created()
+        .append_header(("location", format!("{}/{}", req.path(), id)))
+        .json(json!({"id": id})))
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "readRiskAssessment",
+    params(
+        ("id", Path, description = "The ID of the risk assessment"),
+    ),
+    responses(
+        (status = 200, description = "The risk assessment details", body = RiskAssessment),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+        (status = 404, description = "The risk assessment was not found"),
+    )
+)]
+#[get("/v2/risk-assessment/{id}")]
+/// Get risk assessment details
+async fn read(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    id: web::Path<String>,
+    _: Require<ReadRiskAssessment>,
+) -> actix_web::Result<impl Responder> {
+    let tx = db.begin_read().await?;
+    let result = service.read(&id, &tx).await?;
+
+    Ok(match result {
+        Some(assessment) => HttpResponse::Ok().json(assessment),
+        None => HttpResponse::NotFound().finish(),
+    })
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "listRiskAssessmentsByGroup",
+    params(
+        ("groupId", Path, description = "The ID of the group"),
+    ),
+    responses(
+        (status = 200, description = "Risk assessments for the group", body = Vec<RiskAssessment>),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+    )
+)]
+#[get("/v2/risk-assessment/group/{groupId}")]
+/// Get risk assessments for a group
+async fn list_by_group(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    group_id: web::Path<String>,
+    _: Require<ReadRiskAssessment>,
+) -> actix_web::Result<impl Responder> {
+    let tx = db.begin_read().await?;
+    let result = service.list_by_group(&group_id, &tx).await?;
+
+    Ok(HttpResponse::Ok().json(result))
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "deleteRiskAssessment",
+    params(
+        ("id", Path, description = "The ID of the risk assessment to delete"),
+    ),
+    responses(
+        (status = 204, description = "The risk assessment was deleted or did not exist"),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+    )
+)]
+#[delete("/v2/risk-assessment/{id}")]
+/// Delete a risk assessment
+async fn delete_assessment(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    id: web::Path<String>,
+    _: Require<DeleteRiskAssessment>,
+) -> Result<impl Responder, Error> {
+    let tx = db.begin().await?;
+    service.delete(&id, &tx).await?;
+    tx.commit().await?;
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "uploadRiskAssessmentDocument",
+    params(
+        ("id", Path, description = "The ID of the risk assessment"),
+        ("category", Path, description = "The document category"),
+    ),
+    request_body(content = Vec<u8>, content_type = "application/octet-stream"),
+    responses(
+        (
+            status = 201, description = "The document was uploaded",
+            body = inline(serde_json::Value),
+        ),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+        (status = 404, description = "The risk assessment was not found"),
+    )
+)]
+#[post("/v2/risk-assessment/{id}/document/{category}")]
+/// Upload a document for an assessment category
+async fn upload_document(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    storage: web::Data<DispatchBackend>,
+    path: web::Path<(String, String)>,
+    body: web::Bytes,
+    _: Require<CreateRiskAssessment>,
+) -> Result<impl Responder, Error> {
+    let (assessment_id, category) = path.into_inner();
+    let size = body.len();
+
+    // Compute digests
+    let digests = Digests::digest(&body);
+
+    // Store in storage backend
+    storage
+        .store(&body[..])
+        .await
+        .map_err(|e| Error::Storage(anyhow::anyhow!("{e}")))?;
+
+    // Record in database
+    let doc_id = db
+        .transaction(async |tx| {
+            service
+                .upload_document(&assessment_id, &category, &digests, size, tx)
+                .await
+        })
+        .await?;
+
+    Ok(HttpResponse::Created().json(json!({"id": doc_id})))
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "downloadRiskAssessmentDocument",
+    params(
+        ("id", Path, description = "The ID of the risk assessment"),
+        ("category", Path, description = "The document category"),
+    ),
+    responses(
+        (status = 200, description = "The document content", content_type = "application/octet-stream"),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+        (status = 404, description = "The document was not found"),
+    )
+)]
+#[get("/v2/risk-assessment/{id}/document/{category}")]
+/// Download an assessment document
+async fn download_document(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    storage: web::Data<DispatchBackend>,
+    path: web::Path<(String, String)>,
+    _: Require<ReadRiskAssessment>,
+) -> Result<impl Responder, Error> {
+    let (assessment_id, category) = path.into_inner();
+
+    let tx = db.begin_read().await?;
+    let source_doc = service
+        .get_document_metadata(&assessment_id, &category, &tx)
+        .await?;
+
+    let Some(source_doc) = source_doc else {
+        return Ok(HttpResponse::NotFound().finish());
+    };
+
+    let key = StorageKey::try_from(Id::Sha256(source_doc.sha256))?;
+
+    let stream = storage.retrieve(key).await.map_err(Error::Storage)?;
+
+    Ok(match stream {
+        Some(stream) => HttpResponse::Ok()
+            .content_type("application/octet-stream")
+            .streaming(
+                stream.map_err(|e| actix_web::error::ErrorInternalServerError(e.to_string())),
+            ),
+        None => HttpResponse::NotFound().finish(),
+    })
+}
+
+#[utoipa::path(
+    tag = "risk-assessment",
+    operation_id = "getRiskAssessmentResults",
+    params(
+        ("id", Path, description = "The ID of the risk assessment"),
+    ),
+    responses(
+        (status = 200, description = "The assessment results", body = RiskAssessmentResults),
+        (status = 400, description = "The request was not valid"),
+        (status = 401, description = "The user was not authenticated"),
+        (status = 403, description = "The user authenticated, but not authorized for this operation"),
+        (status = 404, description = "The risk assessment was not found"),
+    )
+)]
+#[get("/v2/risk-assessment/{id}/results")]
+/// Get scoring results for a risk assessment
+async fn get_results(
+    service: web::Data<RiskAssessmentService>,
+    db: web::Data<Database>,
+    id: web::Path<String>,
+    _: Require<ReadRiskAssessment>,
+) -> actix_web::Result<impl Responder> {
+    let tx = db.begin_read().await?;
+    let result = service.get_results(&id, &tx).await?;
+
+    Ok(match result {
+        Some(results) => HttpResponse::Ok().json(results),
+        None => HttpResponse::NotFound().finish(),
+    })
+}

--- a/modules/fundamental/src/risk_assessment/endpoints/test/crud.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/test/crud.rs
@@ -153,6 +153,19 @@ async fn list_by_group(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     let assessments = result.as_array().expect("must be array");
     assert_eq!(assessments.len(), 2);
 
+    for assessment in assessments {
+        assert_eq!(
+            assessment["groupId"].as_str(),
+            Some(group_id.as_str()),
+            "assessment groupId must match requested group"
+        );
+        assert_eq!(
+            assessment["status"].as_str(),
+            Some("pending"),
+            "assessment status must be pending"
+        );
+    }
+
     Ok(())
 }
 

--- a/modules/fundamental/src/risk_assessment/endpoints/test/crud.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/test/crud.rs
@@ -1,0 +1,220 @@
+use crate::test::caller;
+use actix_http::body::to_bytes;
+use actix_web::{http::StatusCode, test::TestRequest};
+use serde_json::{Value, json};
+use test_context::test_context;
+use trustify_test_context::{TrustifyContext, call::CallService};
+
+/// Helper to create an SBOM group and return its ID
+async fn create_group(app: &impl CallService) -> anyhow::Result<String> {
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/group/sbom")
+                .set_json(json!({"name": "test-group-for-risk-assessment"}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    Ok(result["id"].as_str().unwrap().to_string())
+}
+
+/// Helper to create a risk assessment for a group
+async fn create_assessment(app: &impl CallService, group_id: &str) -> anyhow::Result<String> {
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/risk-assessment")
+                .set_json(json!({"groupId": group_id}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    Ok(result["id"].as_str().unwrap().to_string())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn create_risk_assessment(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/risk-assessment")
+                .set_json(json!({"groupId": &group_id}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    assert!(result["id"].as_str().is_some());
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn create_risk_assessment_invalid_group(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/risk-assessment")
+                .set_json(json!({"groupId": "00000000-0000-0000-0000-000000000000"}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn read_risk_assessment(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+    let assessment_id = create_assessment(&app, &group_id).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!("/api/v2/risk-assessment/{}", assessment_id))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    assert_eq!(result["id"].as_str(), Some(assessment_id.as_str()));
+    assert_eq!(result["groupId"].as_str(), Some(group_id.as_str()));
+    assert_eq!(result["status"].as_str(), Some("pending"));
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn read_risk_assessment_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri("/api/v2/risk-assessment/00000000-0000-0000-0000-000000000000")
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn list_by_group(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+
+    // Create two assessments for the same group
+    create_assessment(&app, &group_id).await?;
+    create_assessment(&app, &group_id).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!("/api/v2/risk-assessment/group/{}", group_id))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    let assessments = result.as_array().expect("must be array");
+    assert_eq!(assessments.len(), 2);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn delete_risk_assessment(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+    let assessment_id = create_assessment(&app, &group_id).await?;
+
+    // Delete
+    let response = app
+        .call_service(
+            TestRequest::delete()
+                .uri(&format!("/api/v2/risk-assessment/{}", assessment_id))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Verify it's gone
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!("/api/v2/risk-assessment/{}", assessment_id))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn get_results_empty(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+    let assessment_id = create_assessment(&app, &group_id).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!(
+                    "/api/v2/risk-assessment/{}/results",
+                    assessment_id
+                ))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    assert_eq!(
+        result["assessmentId"].as_str(),
+        Some(assessment_id.as_str())
+    );
+    assert!(result["categories"].as_array().unwrap().is_empty());
+
+    Ok(())
+}

--- a/modules/fundamental/src/risk_assessment/endpoints/test/document.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/test/document.rs
@@ -1,0 +1,114 @@
+use crate::test::caller;
+use actix_http::body::to_bytes;
+use actix_web::{http::StatusCode, test::TestRequest};
+use serde_json::{Value, json};
+use test_context::test_context;
+use trustify_test_context::{TrustifyContext, call::CallService};
+
+/// Helper to create a group
+async fn create_group(app: &impl CallService) -> anyhow::Result<String> {
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/group/sbom")
+                .set_json(json!({"name": "test-group-for-doc-upload"}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    Ok(result["id"].as_str().unwrap().to_string())
+}
+
+/// Helper to create a risk assessment
+async fn create_assessment(app: &impl CallService, group_id: &str) -> anyhow::Result<String> {
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri("/api/v2/risk-assessment")
+                .set_json(json!({"groupId": group_id}))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    Ok(result["id"].as_str().unwrap().to_string())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn upload_and_download_document(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+    let assessment_id = create_assessment(&app, &group_id).await?;
+
+    let pdf_content = b"fake PDF content for testing";
+
+    // Upload document
+    let response = app
+        .call_service(
+            TestRequest::post()
+                .uri(&format!(
+                    "/api/v2/risk-assessment/{}/document/supply-chain",
+                    assessment_id
+                ))
+                .set_payload(pdf_content.to_vec())
+                .insert_header(("content-type", "application/octet-stream"))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    let result: Value = serde_json::from_slice(&body)?;
+    assert!(result["id"].as_str().is_some());
+
+    // Download document
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!(
+                    "/api/v2/risk-assessment/{}/document/supply-chain",
+                    assessment_id
+                ))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body()).await.expect("must decode");
+    assert_eq!(body.as_ref(), pdf_content);
+
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test_log::test(actix_web::test)]
+async fn download_document_not_found(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let app = caller(ctx).await?;
+    let group_id = create_group(&app).await?;
+    let assessment_id = create_assessment(&app, &group_id).await?;
+
+    let response = app
+        .call_service(
+            TestRequest::get()
+                .uri(&format!(
+                    "/api/v2/risk-assessment/{}/document/nonexistent",
+                    assessment_id
+                ))
+                .to_request(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/modules/fundamental/src/risk_assessment/endpoints/test/mod.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/test/mod.rs
@@ -1,0 +1,2 @@
+mod crud;
+mod document;

--- a/modules/fundamental/src/risk_assessment/mod.rs
+++ b/modules/fundamental/src/risk_assessment/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod endpoints;
+pub mod model;
+pub mod service;

--- a/modules/fundamental/src/risk_assessment/model/mod.rs
+++ b/modules/fundamental/src/risk_assessment/model/mod.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RiskAssessment {
+    pub id: String,
+    pub group_id: String,
+    pub status: String,
+    pub overall_score: Option<f64>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
+}
+
+impl From<trustify_entity::risk_assessment::Model> for RiskAssessment {
+    fn from(model: trustify_entity::risk_assessment::Model) -> Self {
+        Self {
+            id: model.id.to_string(),
+            group_id: model.group_id.to_string(),
+            status: model.status,
+            overall_score: model.overall_score,
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRiskAssessmentRequest {
+    pub group_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RiskAssessmentResults {
+    pub assessment_id: String,
+    pub overall_score: Option<f64>,
+    pub categories: Vec<CategoryResult>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CategoryResult {
+    pub category: String,
+    pub document_id: String,
+    pub processed: bool,
+    pub criteria: Vec<CriterionResult>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CriterionResult {
+    pub id: String,
+    pub criterion: String,
+    pub completeness: String,
+    pub risk_level: String,
+    pub score: f64,
+    pub details: Option<serde_json::Value>,
+}

--- a/modules/fundamental/src/risk_assessment/service/mod.rs
+++ b/modules/fundamental/src/risk_assessment/service/mod.rs
@@ -1,0 +1,214 @@
+use crate::Error;
+use crate::risk_assessment::model::*;
+use hex::ToHex;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, Set, query::QueryFilter,
+};
+use time::OffsetDateTime;
+use trustify_common::{db::DatabaseErrors, hashing::Digests};
+use trustify_entity::{
+    risk_assessment, risk_assessment_criteria, risk_assessment_document, source_document,
+};
+use uuid::Uuid;
+
+pub struct RiskAssessmentService;
+
+impl RiskAssessmentService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn create(
+        &self,
+        request: CreateRiskAssessmentRequest,
+        db: &impl ConnectionTrait,
+    ) -> Result<String, Error> {
+        let group_id = Uuid::parse_str(&request.group_id)
+            .map_err(|_| Error::BadRequest("Invalid group_id".into(), None))?;
+
+        let id = Uuid::now_v7();
+        let now = OffsetDateTime::now_utc();
+
+        let model = risk_assessment::ActiveModel {
+            id: Set(id),
+            group_id: Set(group_id),
+            status: Set("pending".to_string()),
+            overall_score: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        };
+
+        model.insert(db).await.map_err(|err| {
+            if err.is_foreign_key_violation() {
+                Error::BadRequest("Group does not exist".into(), None)
+            } else {
+                err.into()
+            }
+        })?;
+
+        Ok(id.to_string())
+    }
+
+    pub async fn read(
+        &self,
+        id: &str,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<RiskAssessment>, Error> {
+        let uuid = Uuid::parse_str(id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        let result = risk_assessment::Entity::find_by_id(uuid).one(db).await?;
+
+        Ok(result.map(RiskAssessment::from))
+    }
+
+    pub async fn list_by_group(
+        &self,
+        group_id: &str,
+        db: &impl ConnectionTrait,
+    ) -> Result<Vec<RiskAssessment>, Error> {
+        let uuid = Uuid::parse_str(group_id)
+            .map_err(|_| Error::BadRequest("Invalid group ID".into(), None))?;
+
+        let results = risk_assessment::Entity::find()
+            .filter(risk_assessment::Column::GroupId.eq(uuid))
+            .all(db)
+            .await?;
+
+        Ok(results.into_iter().map(RiskAssessment::from).collect())
+    }
+
+    pub async fn delete(&self, id: &str, db: &impl ConnectionTrait) -> Result<bool, Error> {
+        let uuid = Uuid::parse_str(id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        let result = risk_assessment::Entity::delete_by_id(uuid).exec(db).await?;
+
+        Ok(result.rows_affected > 0)
+    }
+
+    pub async fn upload_document(
+        &self,
+        assessment_id: &str,
+        category: &str,
+        digests: &Digests,
+        size: usize,
+        db: &impl ConnectionTrait,
+    ) -> Result<String, Error> {
+        let assessment_uuid = Uuid::parse_str(assessment_id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        // Verify assessment exists
+        risk_assessment::Entity::find_by_id(assessment_uuid)
+            .one(db)
+            .await?
+            .ok_or_else(|| Error::NotFound(assessment_id.to_string()))?;
+
+        // Create source document record
+        let source_doc = source_document::ActiveModel {
+            id: Default::default(),
+            sha256: Set(digests.sha256.encode_hex()),
+            sha384: Set(digests.sha384.encode_hex()),
+            sha512: Set(digests.sha512.encode_hex()),
+            size: Set(size as i64),
+            ingested: Set(OffsetDateTime::now_utc()),
+        };
+
+        let source_doc = source_doc.insert(db).await?;
+
+        // Create risk assessment document record
+        let doc_id = Uuid::now_v7();
+        let doc = risk_assessment_document::ActiveModel {
+            id: Set(doc_id),
+            risk_assessment_id: Set(assessment_uuid),
+            category: Set(category.to_string()),
+            source_document_id: Set(source_doc.id),
+            processed: Set(false),
+            uploaded_at: Set(OffsetDateTime::now_utc()),
+        };
+
+        doc.insert(db).await?;
+
+        Ok(doc_id.to_string())
+    }
+
+    pub async fn get_document_metadata(
+        &self,
+        assessment_id: &str,
+        category: &str,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<source_document::Model>, Error> {
+        let assessment_uuid = Uuid::parse_str(assessment_id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        let doc = risk_assessment_document::Entity::find()
+            .filter(risk_assessment_document::Column::RiskAssessmentId.eq(assessment_uuid))
+            .filter(risk_assessment_document::Column::Category.eq(category))
+            .one(db)
+            .await?;
+
+        let Some(doc) = doc else {
+            return Ok(None);
+        };
+
+        let source_doc = source_document::Entity::find_by_id(doc.source_document_id)
+            .one(db)
+            .await?
+            .ok_or_else(|| Error::Internal("Source document missing".to_string()))?;
+
+        Ok(Some(source_doc))
+    }
+
+    pub async fn get_results(
+        &self,
+        assessment_id: &str,
+        db: &impl ConnectionTrait,
+    ) -> Result<Option<RiskAssessmentResults>, Error> {
+        let assessment_uuid = Uuid::parse_str(assessment_id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        let assessment = risk_assessment::Entity::find_by_id(assessment_uuid)
+            .one(db)
+            .await?;
+
+        let Some(assessment) = assessment else {
+            return Ok(None);
+        };
+
+        let documents = risk_assessment_document::Entity::find()
+            .filter(risk_assessment_document::Column::RiskAssessmentId.eq(assessment_uuid))
+            .all(db)
+            .await?;
+
+        let mut categories = Vec::with_capacity(documents.len());
+        for doc in documents {
+            let criteria = risk_assessment_criteria::Entity::find()
+                .filter(risk_assessment_criteria::Column::DocumentId.eq(doc.id))
+                .all(db)
+                .await?;
+
+            categories.push(CategoryResult {
+                category: doc.category,
+                document_id: doc.id.to_string(),
+                processed: doc.processed,
+                criteria: criteria
+                    .into_iter()
+                    .map(|c| CriterionResult {
+                        id: c.id.to_string(),
+                        criterion: c.criterion,
+                        completeness: c.completeness,
+                        risk_level: c.risk_level,
+                        score: c.score,
+                        details: c.details,
+                    })
+                    .collect(),
+            });
+        }
+
+        Ok(Some(RiskAssessmentResults {
+            assessment_id: assessment.id.to_string(),
+            overall_score: assessment.overall_score,
+            categories,
+        }))
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2313,6 +2313,214 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PurlDetails'
+  /api/v2/risk-assessment:
+    post:
+      tags:
+      - risk-assessment
+      summary: Create a new risk assessment for a group
+      operationId: createRiskAssessment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRiskAssessmentRequest'
+        required: true
+      responses:
+        '201':
+          description: Created the risk assessment
+          headers:
+            location:
+              schema:
+                type: string
+              description: The relative URL to the created resource
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+  /api/v2/risk-assessment/group/{groupId}:
+    get:
+      tags:
+      - risk-assessment
+      summary: Get risk assessments for a group
+      operationId: listRiskAssessmentsByGroup
+      parameters:
+      - name: groupId
+        in: path
+        description: The ID of the group
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Risk assessments for the group
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RiskAssessment'
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+  /api/v2/risk-assessment/{id}:
+    get:
+      tags:
+      - risk-assessment
+      summary: Get risk assessment details
+      operationId: readRiskAssessment
+      parameters:
+      - name: id
+        in: path
+        description: The ID of the risk assessment
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The risk assessment details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskAssessment'
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+        '404':
+          description: The risk assessment was not found
+    delete:
+      tags:
+      - risk-assessment
+      summary: Delete a risk assessment
+      operationId: deleteRiskAssessment
+      parameters:
+      - name: id
+        in: path
+        description: The ID of the risk assessment to delete
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: The risk assessment was deleted or did not exist
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+  /api/v2/risk-assessment/{id}/document/{category}:
+    get:
+      tags:
+      - risk-assessment
+      summary: Download an assessment document
+      operationId: downloadRiskAssessmentDocument
+      parameters:
+      - name: id
+        in: path
+        description: The ID of the risk assessment
+        required: true
+        schema:
+          type: string
+      - name: category
+        in: path
+        description: The document category
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The document content
+          content:
+            application/octet-stream: {}
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+        '404':
+          description: The document was not found
+    post:
+      tags:
+      - risk-assessment
+      summary: Upload a document for an assessment category
+      operationId: uploadRiskAssessmentDocument
+      parameters:
+      - name: id
+        in: path
+        description: The ID of the risk assessment
+        required: true
+        schema:
+          type: string
+      - name: category
+        in: path
+        description: The document category
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int32
+                minimum: 0
+        required: true
+      responses:
+        '201':
+          description: The document was uploaded
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+        '404':
+          description: The risk assessment was not found
+  /api/v2/risk-assessment/{id}/results:
+    get:
+      tags:
+      - risk-assessment
+      summary: Get scoring results for a risk assessment
+      operationId: getRiskAssessmentResults
+      parameters:
+      - name: id
+        in: path
+        description: The ID of the risk assessment
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: The assessment results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskAssessmentResults'
+        '400':
+          description: The request was not valid
+        '401':
+          description: The user was not authenticated
+        '403':
+          description: The user authenticated, but not authorized for this operation
+        '404':
+          description: The risk assessment was not found
   /api/v2/sbom:
     get:
       tags:
@@ -3988,6 +4196,24 @@ components:
         size_human:
           $ref: '#/components/schemas/ByteSizeDef'
           description: A human-readable version of `size`
+    CategoryResult:
+      type: object
+      required:
+      - category
+      - documentId
+      - processed
+      - criteria
+      properties:
+        category:
+          type: string
+        criteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/CriterionResult'
+        documentId:
+          type: string
+        processed:
+          type: boolean
     ClearlyDefinedCurationImporter:
       allOf:
       - $ref: '#/components/schemas/CommonImporter'
@@ -4056,6 +4282,34 @@ components:
         id:
           type: string
           description: The ID of the newly created group
+    CreateRiskAssessmentRequest:
+      type: object
+      required:
+      - groupId
+      properties:
+        groupId:
+          type: string
+    CriterionResult:
+      type: object
+      required:
+      - id
+      - criterion
+      - completeness
+      - riskLevel
+      - score
+      properties:
+        completeness:
+          type: string
+        criterion:
+          type: string
+        details: {}
+        id:
+          type: string
+        riskLevel:
+          type: string
+        score:
+          type: number
+          format: double
     CsafImporter:
       allOf:
       - $ref: '#/components/schemas/CommonImporter'
@@ -5454,6 +5708,49 @@ components:
             properties:
               name:
                 type: string
+    RiskAssessment:
+      type: object
+      required:
+      - id
+      - groupId
+      - status
+      - createdAt
+      - updatedAt
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        groupId:
+          type: string
+        id:
+          type: string
+        overallScore:
+          type:
+          - number
+          - 'null'
+          format: double
+        status:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+    RiskAssessmentResults:
+      type: object
+      required:
+      - assessmentId
+      - categories
+      properties:
+        assessmentId:
+          type: string
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/CategoryResult'
+        overallScore:
+          type:
+          - number
+          - 'null'
+          format: double
     SbomAdvisory:
       allOf:
       - $ref: '#/components/schemas/AdvisoryHead'


### PR DESCRIPTION
## Summary

- Add `risk_assessment` module under `modules/fundamental` with endpoints, service, and model submodules
- Implement 7 new REST API endpoints for creating, reading, deleting risk assessments, uploading/downloading documents, and retrieving scoring results
- Add 4 new permissions: `CreateRiskAssessment`, `ReadRiskAssessment`, `UpdateRiskAssessment`, `DeleteRiskAssessment`
- Include integration tests covering CRUD operations, document upload/download, and results retrieval
- Expand `list_by_group` test assertions to validate response shape (groupId, status fields) per review feedback ([JIRAPLAY-1386](https://redhat.atlassian.net/browse/JIRAPLAY-1386))
- Regenerate `openapi.yaml` via `cargo xtask precommit` to include the 7 new risk-assessment endpoints ([JIRAPLAY-1391](https://redhat.atlassian.net/browse/JIRAPLAY-1391))

Implements [JIRAPLAY-1375](https://redhat.atlassian.net/browse/JIRAPLAY-1375)

## Test plan

- [x] `cargo build --all-targets` — compiles without errors
- [x] `cargo test -p trustify-module-fundamental --lib -- risk_assessment` — 9 tests pass
- [x] `cargo clippy --all-targets -p trustify-module-fundamental` — no warnings
- [x] `cargo fmt --check` — formatting correct
- [x] `cargo xtask precommit` — completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)