### PR TITLE
feat(risk-assessment): add LLM integration for SAR document processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +567,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1336,6 +1359,18 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -2508,6 +2543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ena"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -2561,6 +2606,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
+ "jiff",
  "log",
 ]
 
@@ -2603,6 +2649,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2690,21 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_json",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "filetime"
@@ -2739,6 +2811,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fortified-llm-client"
+version = "0.1.0"
+source = "git+https://github.com/mrizzi/fortified-llm-client.git#ab0212d838b3a27c40d1f72e4c9d68f41e16fcc5"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "clap",
+ "dotenvy",
+ "env_logger",
+ "figment",
+ "futures",
+ "jsonschema",
+ "log",
+ "once_cell",
+ "regex",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3106,7 +3213,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3730,6 +3837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +3938,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +4033,35 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba783d17473c27cfd4d1d72785dc1c26d5faba8072f50fec4ebea179bec8f33d"
+dependencies = [
+ "ahash 0.8.12",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest 0.13.2",
+ "rustls 0.23.37",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -4385,6 +4551,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,6 +4591,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4432,6 +4627,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -5011,6 +5217,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc90935a8dd139fdf341762773687a1e361d3f54b396a55d9dd1f7001e484bb"
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,6 +5509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postgresql_archive"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,7 +5646,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -5716,6 +5954,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef39a30a317e883d1ef4c43aa849f90f480d90bb24904fd38266e61d6be58f2"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -6828,6 +7081,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7861,6 +8132,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7871,12 +8178,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -7889,6 +8210,18 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tonic"
@@ -8374,6 +8707,7 @@ dependencies = [
  "csv",
  "cve",
  "flate2",
+ "fortified-llm-client",
  "futures-util",
  "hex",
  "humantime",
@@ -8405,6 +8739,7 @@ dependencies = [
  "spdx-rs",
  "strum 0.27.2",
  "tar",
+ "temp-env",
  "test-context",
  "test-log",
  "thiserror 2.0.18",
@@ -8773,6 +9108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8783,6 +9127,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -8985,6 +9335,16 @@ dependencies = [
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8740,6 +8740,7 @@ dependencies = [
  "strum 0.27.2",
  "tar",
  "temp-env",
+ "tempfile",
  "test-context",
  "test-log",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ deepsize = "0.2.0"
 dotenvy = "0.15.7"
 fixedbitset = "0.5.7"
 flate2 = "1.0.35"
+fortified-llm-client = { git = "https://github.com/mrizzi/fortified-llm-client.git", version = "0.1.0" }
 fs4 = "0.13.1"
 futures = "0.3.30"
 futures-util = "0.3"

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -52,6 +52,12 @@
 | `TRUSTD_STORAGE_STRATEGY`                | Specifies the storage strategy to use                                               | `File system`                           |
 | `UI_CLIENT_ID`                           | Client ID used by the UI                                                            | `frontend`                              |
 | `UI_ISSUER_URL`                          | Issuer URL used by the UI                                                           | `http://localhost:8090/realms/trustify` |
+| `TRUSTD_LLM_API_URL`                     | LLM API endpoint URL (enables LLM-based document processing when set with MODEL)   |                                         |
+| `TRUSTD_LLM_MODEL`                       | LLM model identifier (e.g., `llama3`, `gpt-4`)                                     |                                         |
+| `TRUSTD_LLM_API_KEY`                     | API key for LLM authentication                                                      |                                         |
+| `TRUSTD_LLM_TEMPERATURE`                | Sampling temperature for LLM responses                                               | `0.2`                                   |
+| `TRUSTD_LLM_TIMEOUT_SECS`               | Request timeout in seconds for LLM calls                                             | `120`                                   |
+| `TRUSTD_LLM_MAX_TOKENS`                 | Maximum tokens to generate in LLM response                                           |                                         |
 | `UI_SCOPE`                               | Scopes to request                                                                   | `openid`                                |
 
 ## Development 

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -40,6 +40,7 @@ spdx = { workspace = true, features = ["text"] }
 spdx-expression = { workspace = true }
 strum = { workspace = true }
 tar = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = { workspace = true }
 cpe = { workspace = true }
 csv = { workspace = true }
 flate2 ={ workspace = true }
+fortified-llm-client = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
 isx = { workspace = true }
@@ -82,6 +83,7 @@ sha2 = { workspace = true }
 spdx-rs = { workspace = true }
 strum = { workspace = true }
 tar = { workspace = true }
+temp-env = { workspace = true }
 test-context = { workspace = true }
 test-log = { workspace = true, features = ["log", "trace"] }
 tokio-util = { workspace = true }

--- a/modules/fundamental/src/risk_assessment/endpoints/mod.rs
+++ b/modules/fundamental/src/risk_assessment/endpoints/mod.rs
@@ -7,6 +7,7 @@ use actix_web::{HttpRequest, HttpResponse, Responder, delete, get, post, web};
 use futures_util::stream::TryStreamExt;
 use sea_orm::TransactionTrait;
 use serde_json::json;
+use std::io::Write;
 use trustify_auth::{
     CreateRiskAssessment, DeleteRiskAssessment, ReadRiskAssessment, authorizer::Require,
 };
@@ -203,6 +204,21 @@ async fn upload_document(
                 .await
         })
         .await?;
+
+    // If LLM processing is configured, evaluate the document
+    if service.processing_enabled() {
+        let mut tmp = tempfile::NamedTempFile::new()
+            .map_err(|e| Error::Internal(format!("Failed to create temp file: {e}")))?;
+        tmp.write_all(&body)
+            .map_err(|e| Error::Internal(format!("Failed to write temp file: {e}")))?;
+
+        db.transaction(async |tx| {
+            service
+                .process_document(&assessment_id, &doc_id, tmp.path(), tx)
+                .await
+        })
+        .await?;
+    }
 
     Ok(HttpResponse::Created().json(json!({"id": doc_id})))
 }

--- a/modules/fundamental/src/risk_assessment/service/document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/document_processor.rs
@@ -1,0 +1,160 @@
+use crate::Error;
+use fortified_llm_client::{InvokeParams, LlmClient, ResponseFormat};
+use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+use trustify_entity::risk_assessment_criteria;
+use uuid::Uuid;
+
+use super::llm_config::LlmConfig;
+
+const SAR_SYSTEM_PROMPT: &str = include_str!("prompts/sar_system.txt");
+const SAR_USER_TEMPLATE: &str = include_str!("prompts/sar_user.txt");
+
+/// Result of evaluating a single NIST 800-30 criterion.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CriterionEvaluation {
+    pub completeness: String,
+    pub risk_level: String,
+    pub score: f64,
+    pub details: Option<serde_json::Value>,
+}
+
+/// LLM response containing per-criterion evaluations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SarEvaluationResponse {
+    pub criteria: HashMap<String, CriterionEvaluation>,
+}
+
+/// Extract text content from a PDF file.
+pub async fn extract_text_from_pdf(path: &Path) -> Result<String, Error> {
+    let content = fortified_llm_client::extract_text_from_pdf(path)
+        .await
+        .map_err(|e| Error::Internal(format!("PDF extraction failed: {e}")))?;
+    Ok(content.text)
+}
+
+/// Build the JSON schema for structured LLM output.
+fn sar_response_format() -> ResponseFormat {
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "criteria": {
+                "type": "object",
+                "properties": {
+                    "threat_identification": { "$ref": "#/$defs/criterion" },
+                    "vulnerability_identification": { "$ref": "#/$defs/criterion" },
+                    "likelihood_assessment": { "$ref": "#/$defs/criterion" },
+                    "impact_analysis": { "$ref": "#/$defs/criterion" },
+                    "risk_determination": { "$ref": "#/$defs/criterion" },
+                    "security_controls": { "$ref": "#/$defs/criterion" },
+                    "risk_mitigation": { "$ref": "#/$defs/criterion" }
+                },
+                "required": [
+                    "threat_identification",
+                    "vulnerability_identification",
+                    "likelihood_assessment",
+                    "impact_analysis",
+                    "risk_determination",
+                    "security_controls",
+                    "risk_mitigation"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "required": ["criteria"],
+        "additionalProperties": false,
+        "$defs": {
+            "criterion": {
+                "type": "object",
+                "properties": {
+                    "completeness": {
+                        "type": "string",
+                        "enum": ["complete", "partial", "missing"]
+                    },
+                    "risk_level": {
+                        "type": "string",
+                        "enum": ["low", "moderate", "high", "critical"]
+                    },
+                    "score": {
+                        "type": "number",
+                        "minimum": 0.0,
+                        "maximum": 1.0
+                    },
+                    "details": {
+                        "type": "object",
+                        "properties": {
+                            "summary": { "type": "string" }
+                        },
+                        "required": ["summary"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["completeness", "risk_level", "score", "details"],
+                "additionalProperties": false
+            }
+        }
+    });
+
+    ResponseFormat::json_schema("sar_evaluation".to_string(), schema, true)
+}
+
+/// Evaluate document text against NIST 800-30 criteria using an LLM.
+pub async fn evaluate_document(
+    config: &LlmConfig,
+    document_text: &str,
+) -> Result<SarEvaluationResponse, Error> {
+    let client = LlmClient::new(config.api_url.clone(), None);
+
+    let user_prompt = SAR_USER_TEMPLATE.replace("{document_text}", document_text);
+    let response_format = sar_response_format();
+
+    let params = InvokeParams {
+        model: &config.model,
+        system_prompt: SAR_SYSTEM_PROMPT,
+        user_prompt: &user_prompt,
+        temperature: config.temperature,
+        max_tokens: config.max_tokens,
+        seed: None,
+        api_key: config.api_key.as_deref(),
+        timeout_secs: config.timeout_secs,
+        response_format: Some(&response_format),
+    };
+
+    let response_text = client
+        .invoke(params)
+        .await
+        .map_err(|e| Error::Internal(format!("LLM invocation failed: {e}")))?;
+
+    let evaluation: SarEvaluationResponse = serde_json::from_str(&response_text)
+        .map_err(|e| Error::Internal(format!("Failed to parse LLM response: {e}")))?;
+
+    Ok(evaluation)
+}
+
+/// Persist evaluation results to the risk_assessment_criteria table.
+pub async fn store_criteria_results(
+    document_id: Uuid,
+    evaluation: &SarEvaluationResponse,
+    db: &impl ConnectionTrait,
+) -> Result<Vec<Uuid>, Error> {
+    let mut ids = Vec::with_capacity(evaluation.criteria.len());
+
+    for (criterion_name, result) in &evaluation.criteria {
+        let id = Uuid::now_v7();
+        let model = risk_assessment_criteria::ActiveModel {
+            id: Set(id),
+            document_id: Set(document_id),
+            criterion: Set(criterion_name.clone()),
+            completeness: Set(result.completeness.clone()),
+            risk_level: Set(result.risk_level.clone()),
+            score: Set(result.score),
+            details: Set(result.details.clone()),
+        };
+        model.insert(db).await?;
+        ids.push(id);
+    }
+
+    Ok(ids)
+}

--- a/modules/fundamental/src/risk_assessment/service/llm_config.rs
+++ b/modules/fundamental/src/risk_assessment/service/llm_config.rs
@@ -1,0 +1,137 @@
+use std::env;
+
+/// LLM configuration loaded from environment variables.
+///
+/// Environment variables:
+/// - `TRUSTD_LLM_API_URL` — LLM API endpoint URL (required)
+/// - `TRUSTD_LLM_MODEL` — Model identifier (required)
+/// - `TRUSTD_LLM_API_KEY` — API key for authentication (optional)
+/// - `TRUSTD_LLM_TEMPERATURE` — Sampling temperature, default `0.2`
+/// - `TRUSTD_LLM_TIMEOUT_SECS` — Request timeout in seconds, default `120`
+/// - `TRUSTD_LLM_MAX_TOKENS` — Maximum tokens to generate (optional)
+#[derive(Debug, Clone)]
+pub struct LlmConfig {
+    pub api_url: String,
+    pub model: String,
+    pub api_key: Option<String>,
+    pub temperature: f32,
+    pub timeout_secs: u64,
+    pub max_tokens: Option<u32>,
+}
+
+impl LlmConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Returns `None` if `TRUSTD_LLM_API_URL` or `TRUSTD_LLM_MODEL` are not set,
+    /// indicating LLM features are disabled.
+    pub fn from_env() -> Option<Self> {
+        let api_url = env::var("TRUSTD_LLM_API_URL").ok()?;
+        let model = env::var("TRUSTD_LLM_MODEL").ok()?;
+
+        let api_key = env::var("TRUSTD_LLM_API_KEY").ok();
+
+        let temperature = env::var("TRUSTD_LLM_TEMPERATURE")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .unwrap_or(0.2);
+
+        let timeout_secs = env::var("TRUSTD_LLM_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(120);
+
+        let max_tokens = env::var("TRUSTD_LLM_MAX_TOKENS")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok());
+
+        Some(Self {
+            api_url,
+            model,
+            api_key,
+            temperature,
+            timeout_secs,
+            max_tokens,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_env_returns_none_when_not_set() {
+        // Without TRUSTD_LLM_API_URL and TRUSTD_LLM_MODEL set, should return None
+        temp_env::with_vars_unset(["TRUSTD_LLM_API_URL", "TRUSTD_LLM_MODEL"], || {
+            assert!(LlmConfig::from_env().is_none());
+        });
+    }
+
+    #[test]
+    fn test_from_env_with_required_vars() {
+        temp_env::with_vars(
+            [
+                (
+                    "TRUSTD_LLM_API_URL",
+                    Some("http://localhost:11434/v1/chat/completions"),
+                ),
+                ("TRUSTD_LLM_MODEL", Some("llama3")),
+            ],
+            || {
+                let config = LlmConfig::from_env();
+                assert!(config.is_some());
+                let config = config.unwrap();
+                assert_eq!(config.api_url, "http://localhost:11434/v1/chat/completions");
+                assert_eq!(config.model, "llama3");
+                assert!(config.api_key.is_none());
+                assert!((config.temperature - 0.2).abs() < f32::EPSILON);
+                assert_eq!(config.timeout_secs, 120);
+                assert!(config.max_tokens.is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn test_from_env_with_all_vars() {
+        temp_env::with_vars(
+            [
+                (
+                    "TRUSTD_LLM_API_URL",
+                    Some("http://api.example.com/v1/chat/completions"),
+                ),
+                ("TRUSTD_LLM_MODEL", Some("gpt-4")),
+                ("TRUSTD_LLM_API_KEY", Some("sk-test-key")),
+                ("TRUSTD_LLM_TEMPERATURE", Some("0.7")),
+                ("TRUSTD_LLM_TIMEOUT_SECS", Some("60")),
+                ("TRUSTD_LLM_MAX_TOKENS", Some("4096")),
+            ],
+            || {
+                let config = LlmConfig::from_env().unwrap();
+                assert_eq!(config.api_url, "http://api.example.com/v1/chat/completions");
+                assert_eq!(config.model, "gpt-4");
+                assert_eq!(config.api_key.as_deref(), Some("sk-test-key"));
+                assert!((config.temperature - 0.7).abs() < f32::EPSILON);
+                assert_eq!(config.timeout_secs, 60);
+                assert_eq!(config.max_tokens, Some(4096));
+            },
+        );
+    }
+
+    #[test]
+    fn test_from_env_with_invalid_temperature_uses_default() {
+        temp_env::with_vars(
+            [
+                (
+                    "TRUSTD_LLM_API_URL",
+                    Some("http://localhost:11434/v1/chat/completions"),
+                ),
+                ("TRUSTD_LLM_MODEL", Some("llama3")),
+                ("TRUSTD_LLM_TEMPERATURE", Some("not-a-number")),
+            ],
+            || {
+                let config = LlmConfig::from_env().unwrap();
+                assert!((config.temperature - 0.2).abs() < f32::EPSILON);
+            },
+        );
+    }
+}

--- a/modules/fundamental/src/risk_assessment/service/mod.rs
+++ b/modules/fundamental/src/risk_assessment/service/mod.rs
@@ -1,3 +1,9 @@
+#[cfg(test)]
+mod test_document_processor;
+
+pub mod document_processor;
+pub mod llm_config;
+
 use crate::Error;
 use crate::risk_assessment::model::*;
 use hex::ToHex;
@@ -11,11 +17,22 @@ use trustify_entity::{
 };
 use uuid::Uuid;
 
-pub struct RiskAssessmentService;
+use self::llm_config::LlmConfig;
+
+pub struct RiskAssessmentService {
+    llm_config: Option<LlmConfig>,
+}
 
 impl RiskAssessmentService {
     pub fn new() -> Self {
-        Self
+        Self {
+            llm_config: LlmConfig::from_env(),
+        }
+    }
+
+    /// Returns whether LLM-based document processing is enabled.
+    pub fn processing_enabled(&self) -> bool {
+        self.llm_config.is_some()
     }
 
     pub async fn create(
@@ -210,5 +227,67 @@ impl RiskAssessmentService {
             overall_score: assessment.overall_score,
             categories,
         }))
+    }
+
+    /// Process a document: extract PDF text, evaluate with LLM, and store results.
+    ///
+    /// The `pdf_path` should point to a temporary file containing the PDF content
+    /// retrieved from storage.
+    pub async fn process_document(
+        &self,
+        assessment_id: &str,
+        document_id: &str,
+        pdf_path: &std::path::Path,
+        db: &impl ConnectionTrait,
+    ) -> Result<Vec<Uuid>, Error> {
+        let config = self
+            .llm_config
+            .as_ref()
+            .ok_or_else(|| Error::Internal("LLM processing is not configured".to_string()))?;
+
+        let doc_uuid = Uuid::parse_str(document_id)
+            .map_err(|_| Error::BadRequest("Invalid document ID".into(), None))?;
+
+        let assessment_uuid = Uuid::parse_str(assessment_id)
+            .map_err(|_| Error::BadRequest("Invalid assessment ID".into(), None))?;
+
+        // Verify document exists
+        risk_assessment_document::Entity::find_by_id(doc_uuid)
+            .one(db)
+            .await?
+            .ok_or_else(|| Error::NotFound(document_id.to_string()))?;
+
+        // Extract text from PDF
+        let text = document_processor::extract_text_from_pdf(pdf_path).await?;
+
+        // Evaluate against NIST 800-30 criteria
+        let evaluation = document_processor::evaluate_document(config, &text).await?;
+
+        // Store criteria results
+        let ids = document_processor::store_criteria_results(doc_uuid, &evaluation, db).await?;
+
+        // Mark document as processed
+        let doc_update = risk_assessment_document::ActiveModel {
+            id: Set(doc_uuid),
+            processed: Set(true),
+            ..Default::default()
+        };
+        doc_update.update(db).await?;
+
+        // Compute overall score as average of all criteria scores
+        let total: f64 = evaluation.criteria.values().map(|c| c.score).sum();
+        let count = evaluation.criteria.len() as f64;
+        let overall_score = if count > 0.0 { total / count } else { 0.0 };
+
+        let assessment_update = risk_assessment::ActiveModel {
+            id: Set(assessment_uuid),
+            overall_score: Set(Some(overall_score)),
+            status: Set("completed".to_string()),
+            updated_at: Set(OffsetDateTime::now_utc()),
+            ..Default::default()
+        };
+        assessment_update.update(db).await?;
+
+        Ok(ids)
     }
 }

--- a/modules/fundamental/src/risk_assessment/service/prompts/sar_system.txt
+++ b/modules/fundamental/src/risk_assessment/service/prompts/sar_system.txt
@@ -1,0 +1,18 @@
+You are a cybersecurity risk assessment expert specializing in NIST SP 800-30 (Guide for Conducting Risk Assessments). Your task is to evaluate a Security Architecture Review (SAR) document against the NIST 800-30 risk assessment criteria.
+
+For each criterion, you must evaluate:
+1. **Completeness** — How thoroughly the document addresses this criterion. Values: "complete", "partial", "missing".
+2. **Risk Level** — The residual risk level based on what the document describes. Values: "low", "moderate", "high", "critical".
+3. **Score** — A numeric score from 0.0 to 1.0 where 1.0 means the criterion is fully addressed with low residual risk.
+4. **Details** — A JSON object with a "summary" field explaining the rationale for your assessment.
+
+Evaluate the following NIST 800-30 criteria:
+- **threat_identification**: Identification of threat sources and threat events relevant to the system.
+- **vulnerability_identification**: Identification of vulnerabilities in the system that could be exploited.
+- **likelihood_assessment**: Assessment of the likelihood that identified threats will exploit vulnerabilities.
+- **impact_analysis**: Analysis of the potential impact if threats successfully exploit vulnerabilities.
+- **risk_determination**: Determination of risk based on the combination of likelihood and impact.
+- **security_controls**: Evaluation of existing and planned security controls and their effectiveness.
+- **risk_mitigation**: Proposed risk mitigation strategies and their adequacy.
+
+You must respond with valid JSON matching the required schema. Be precise and objective in your assessments.

--- a/modules/fundamental/src/risk_assessment/service/prompts/sar_user.txt
+++ b/modules/fundamental/src/risk_assessment/service/prompts/sar_user.txt
@@ -1,0 +1,5 @@
+Please evaluate the following Security Architecture Review (SAR) document against the NIST 800-30 risk assessment criteria.
+
+Document content:
+
+{document_text}

--- a/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
@@ -1,0 +1,130 @@
+use crate::risk_assessment::service::RiskAssessmentService;
+use crate::risk_assessment::service::document_processor::{
+    CriterionEvaluation, SarEvaluationResponse, store_criteria_results,
+};
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, TransactionTrait};
+use std::collections::HashMap;
+use test_context::test_context;
+use test_log::test;
+use trustify_test_context::TrustifyContext;
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn test_processing_disabled_without_env(_ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    temp_env::with_vars_unset(["TRUSTD_LLM_API_URL", "TRUSTD_LLM_MODEL"], || {
+        let service = RiskAssessmentService::new();
+        assert!(!service.processing_enabled());
+    });
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn test_processing_enabled_with_env(_ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    temp_env::with_vars(
+        [
+            (
+                "TRUSTD_LLM_API_URL",
+                Some("http://localhost:11434/v1/chat/completions"),
+            ),
+            ("TRUSTD_LLM_MODEL", Some("llama3")),
+        ],
+        || {
+            let service = RiskAssessmentService::new();
+            assert!(service.processing_enabled());
+        },
+    );
+    Ok(())
+}
+
+#[test_context(TrustifyContext)]
+#[test(actix_web::test)]
+async fn test_store_criteria_results(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
+    let db = &ctx.db;
+    let tx = db.begin().await?;
+
+    // Create a risk assessment and document for the test
+    let service = RiskAssessmentService::new();
+    let group_id = create_test_group(&tx).await?;
+
+    let assessment_id = service
+        .create(
+            crate::risk_assessment::model::CreateRiskAssessmentRequest {
+                group_id: group_id.clone(),
+            },
+            &tx,
+        )
+        .await?;
+
+    let digests = trustify_common::hashing::Digests::digest("test pdf content");
+    let doc_id = service
+        .upload_document(&assessment_id, "sar", &digests, 16, &tx)
+        .await?;
+
+    let doc_uuid = uuid::Uuid::parse_str(&doc_id)?;
+
+    // Build a mock evaluation response
+    let mut criteria = HashMap::new();
+    criteria.insert(
+        "threat_identification".to_string(),
+        CriterionEvaluation {
+            completeness: "complete".to_string(),
+            risk_level: "low".to_string(),
+            score: 0.9,
+            details: Some(serde_json::json!({"summary": "Threats are well identified"})),
+        },
+    );
+    criteria.insert(
+        "vulnerability_identification".to_string(),
+        CriterionEvaluation {
+            completeness: "partial".to_string(),
+            risk_level: "moderate".to_string(),
+            score: 0.6,
+            details: Some(serde_json::json!({"summary": "Some vulnerabilities missing"})),
+        },
+    );
+
+    let evaluation = SarEvaluationResponse { criteria };
+
+    // Store and verify
+    let ids = store_criteria_results(doc_uuid, &evaluation, &tx).await?;
+    assert_eq!(ids.len(), 2);
+
+    // Verify results are retrievable
+    let results = service.get_results(&assessment_id, &tx).await?;
+    assert!(results.is_some());
+    let results = results.unwrap();
+    assert_eq!(results.categories.len(), 1);
+    assert_eq!(results.categories[0].criteria.len(), 2);
+
+    // Verify individual criterion values
+    let threat = results.categories[0]
+        .criteria
+        .iter()
+        .find(|c| c.criterion == "threat_identification");
+    assert!(threat.is_some());
+    let threat = threat.unwrap();
+    assert_eq!(threat.completeness, "complete");
+    assert_eq!(threat.risk_level, "low");
+    assert!((threat.score - 0.9).abs() < f64::EPSILON);
+
+    tx.rollback().await?;
+    Ok(())
+}
+
+async fn create_test_group(db: &impl ConnectionTrait) -> Result<String, anyhow::Error> {
+    let group_id = uuid::Uuid::now_v7();
+    let revision = uuid::Uuid::now_v7();
+    db.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        "INSERT INTO sbom_group (id, name, revision, labels) VALUES ($1, $2, $3, $4)",
+        [
+            group_id.into(),
+            "test-group".into(),
+            revision.into(),
+            serde_json::json!({}).into(),
+        ],
+    ))
+    .await?;
+    Ok(group_id.to_string())
+}


### PR DESCRIPTION
## Summary

- Integrate `fortified-llm-client` as a workspace dependency for PDF text extraction and LLM invocation
- Add LLM configuration infrastructure loaded from environment variables (`TRUSTD_LLM_*`)
- Implement SAR document processing service that evaluates uploaded PDFs against NIST 800-30 criteria using an LLM with structured JSON output
- Add system and user prompt templates for NIST 800-30 risk evaluation
- Document new environment variables in `docs/env-vars.md`

Implements [JIRAPLAY-1376](https://redhat.atlassian.net/browse/JIRAPLAY-1376)

## Test plan

- [x] Unit tests for LLM config loading from env vars (4 tests)
- [x] Integration test for `store_criteria_results` with mock evaluation data
- [x] Integration tests for `processing_enabled`/`processing_disabled` based on env vars
- [x] All 16 risk_assessment tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` — only expected dead_code warnings (service methods not yet called from endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate LLM-backed SAR document processing into the risk assessment service, driven by environment-based configuration and persisted evaluation results.

New Features:
- Add optional LLM configuration for risk assessment loaded from TRUSTD_LLM_* environment variables to toggle document processing.
- Introduce a document processing workflow that extracts PDF text, evaluates it against NIST 800-30 criteria via an LLM, and updates assessment scores and status.
- Define structured schema and types for per-criterion SAR evaluations and persist results to the risk_assessment_criteria table.

Enhancements:
- Extend the risk assessment service to track whether LLM processing is enabled and to compute an overall assessment score from stored criteria.
- Add LLM prompt templates for SAR system and user messages to standardize NIST 800-30 evaluations.

Build:
- Add fortified-llm-client and temp-env as dependencies to enable LLM interactions, PDF extraction, and env-based configuration in the fundamental module.

Documentation:
- Document new TRUSTD_LLM_* environment variables controlling LLM integration and behavior in env-vars.md.

Tests:
- Add unit tests for LLM configuration loading from environment variables and for enabling/disabling processing based on configuration.
- Add integration-style tests that store and retrieve mock SAR evaluation criteria results within the risk assessment flow.