### PR TITLE
feat(risk-assessment): adapt document processor to new LLM response schema

### DIFF
--- a/entity/src/risk_assessment_criteria.rs
+++ b/entity/src/risk_assessment_criteria.rs
@@ -12,6 +12,10 @@ pub struct Model {
     pub risk_level: String,
     pub score: f64,
     pub details: Option<serde_json::Value>,
+    pub what_documented: Option<serde_json::Value>,
+    pub gaps: Option<serde_json::Value>,
+    pub impact_description: Option<String>,
+    pub recommendations: Option<serde_json::Value>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/migration/src/m0002160_create_risk_assessment.rs
+++ b/migration/src/m0002160_create_risk_assessment.rs
@@ -133,19 +133,10 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(RiskAssessmentCriteria::Details).json_binary())
-                    .col(
-                        ColumnDef::new(RiskAssessmentCriteria::WhatDocumented)
-                            .json_binary(),
-                    )
+                    .col(ColumnDef::new(RiskAssessmentCriteria::WhatDocumented).json_binary())
                     .col(ColumnDef::new(RiskAssessmentCriteria::Gaps).json_binary())
-                    .col(
-                        ColumnDef::new(RiskAssessmentCriteria::ImpactDescription)
-                            .string(),
-                    )
-                    .col(
-                        ColumnDef::new(RiskAssessmentCriteria::Recommendations)
-                            .json_binary(),
-                    )
+                    .col(ColumnDef::new(RiskAssessmentCriteria::ImpactDescription).string())
+                    .col(ColumnDef::new(RiskAssessmentCriteria::Recommendations).json_binary())
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(RiskAssessmentCriteria::DocumentId)

--- a/migration/src/m0002160_create_risk_assessment.rs
+++ b/migration/src/m0002160_create_risk_assessment.rs
@@ -133,6 +133,19 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(ColumnDef::new(RiskAssessmentCriteria::Details).json_binary())
+                    .col(
+                        ColumnDef::new(RiskAssessmentCriteria::WhatDocumented)
+                            .json_binary(),
+                    )
+                    .col(ColumnDef::new(RiskAssessmentCriteria::Gaps).json_binary())
+                    .col(
+                        ColumnDef::new(RiskAssessmentCriteria::ImpactDescription)
+                            .string(),
+                    )
+                    .col(
+                        ColumnDef::new(RiskAssessmentCriteria::Recommendations)
+                            .json_binary(),
+                    )
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(RiskAssessmentCriteria::DocumentId)
@@ -255,6 +268,10 @@ enum RiskAssessmentCriteria {
     RiskLevel,
     Score,
     Details,
+    WhatDocumented,
+    Gaps,
+    ImpactDescription,
+    Recommendations,
 }
 
 #[derive(DeriveIden)]

--- a/modules/fundamental/src/risk_assessment/service/document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/document_processor.rs
@@ -1,8 +1,8 @@
 use crate::Error;
 use fortified_llm_client::{InvokeParams, LlmClient, ResponseFormat};
 use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
-use serde::Deserialize;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::path::Path;
 use trustify_entity::risk_assessment_criteria;
 use uuid::Uuid;
@@ -11,20 +11,47 @@ use super::llm_config::LlmConfig;
 
 const SAR_SYSTEM_PROMPT: &str = include_str!("prompts/sar_system.txt");
 const SAR_USER_TEMPLATE: &str = include_str!("prompts/sar_user.txt");
+const RESPONSE_FORMAT_SCHEMA: &str = include_str!("prompts/response_schema.json");
 
-/// Result of evaluating a single NIST 800-30 criterion.
-#[derive(Debug, Clone, Deserialize)]
-pub struct CriterionEvaluation {
-    pub completeness: String,
-    pub risk_level: String,
-    pub score: f64,
-    pub details: Option<serde_json::Value>,
+/// A single recommendation action with priority.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recommendation {
+    pub action: String,
+    pub priority: String,
 }
 
-/// LLM response containing per-criterion evaluations.
+/// Completeness assessment for a single NIST 800-30 criterion.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CriterionAssessment {
+    pub number: i32,
+    pub name: String,
+    pub rating: String,
+    pub what_documented: Vec<String>,
+    pub gaps: Vec<String>,
+    pub impact: String,
+    pub recommendations: Vec<Recommendation>,
+}
+
+/// Risk level with score and NIST level classification.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RiskLevel {
+    pub score: f64,
+    pub level: String,
+}
+
+/// Risk assessment for a criterion rated partial or missing.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RiskAssessmentEntry {
+    pub criterion_number: i32,
+    pub risk_level: RiskLevel,
+}
+
+/// Top-level LLM response matching the `response_schema.json` structure.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SarEvaluationResponse {
-    pub criteria: HashMap<String, CriterionEvaluation>,
+    pub criteria_assessments: Vec<CriterionAssessment>,
+    pub risk_assessments: Vec<RiskAssessmentEntry>,
+    // risk_prioritization is present in the schema but not stored per-criterion.
 }
 
 /// Extract text content from a PDF file.
@@ -37,65 +64,8 @@ pub async fn extract_text_from_pdf(path: &Path) -> Result<String, Error> {
 
 /// Build the JSON schema for structured LLM output.
 fn sar_response_format() -> ResponseFormat {
-    let schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "criteria": {
-                "type": "object",
-                "properties": {
-                    "threat_identification": { "$ref": "#/$defs/criterion" },
-                    "vulnerability_identification": { "$ref": "#/$defs/criterion" },
-                    "likelihood_assessment": { "$ref": "#/$defs/criterion" },
-                    "impact_analysis": { "$ref": "#/$defs/criterion" },
-                    "risk_determination": { "$ref": "#/$defs/criterion" },
-                    "security_controls": { "$ref": "#/$defs/criterion" },
-                    "risk_mitigation": { "$ref": "#/$defs/criterion" }
-                },
-                "required": [
-                    "threat_identification",
-                    "vulnerability_identification",
-                    "likelihood_assessment",
-                    "impact_analysis",
-                    "risk_determination",
-                    "security_controls",
-                    "risk_mitigation"
-                ],
-                "additionalProperties": false
-            }
-        },
-        "required": ["criteria"],
-        "additionalProperties": false,
-        "$defs": {
-            "criterion": {
-                "type": "object",
-                "properties": {
-                    "completeness": {
-                        "type": "string",
-                        "enum": ["complete", "partial", "missing"]
-                    },
-                    "risk_level": {
-                        "type": "string",
-                        "enum": ["low", "moderate", "high", "critical"]
-                    },
-                    "score": {
-                        "type": "number",
-                        "minimum": 0.0,
-                        "maximum": 1.0
-                    },
-                    "details": {
-                        "type": "object",
-                        "properties": {
-                            "summary": { "type": "string" }
-                        },
-                        "required": ["summary"],
-                        "additionalProperties": false
-                    }
-                },
-                "required": ["completeness", "risk_level", "score", "details"],
-                "additionalProperties": false
-            }
-        }
-    });
+    let schema: Value = serde_json::from_str(RESPONSE_FORMAT_SCHEMA)
+        .unwrap_or_else(|e| panic!("Invalid response_schema.json: {e}"));
 
     ResponseFormat::json_schema("sar_evaluation".to_string(), schema, true)
 }
@@ -133,24 +103,62 @@ pub async fn evaluate_document(
     Ok(evaluation)
 }
 
+/// Convert an underscore-separated risk level (e.g. `very_high`) to title case (e.g. `Very high`).
+fn format_risk_level(level: &str) -> String {
+    let mut chars = level.replace('_', " ").chars().collect::<Vec<_>>();
+    if let Some(first) = chars.first_mut() {
+        *first = first.to_uppercase().next().unwrap_or(*first);
+    }
+    chars.into_iter().collect()
+}
+
 /// Persist evaluation results to the risk_assessment_criteria table.
+///
+/// Joins `criteria_assessments` with `risk_assessments` by criterion number to
+/// combine completeness data with risk scores. Criteria rated "complete" that
+/// have no corresponding risk assessment receive a default low risk level.
 pub async fn store_criteria_results(
     document_id: Uuid,
     evaluation: &SarEvaluationResponse,
     db: &impl ConnectionTrait,
 ) -> Result<Vec<Uuid>, Error> {
-    let mut ids = Vec::with_capacity(evaluation.criteria.len());
+    let mut ids = Vec::with_capacity(evaluation.criteria_assessments.len());
 
-    for (criterion_name, result) in &evaluation.criteria {
+    // Build a lookup of risk assessments by criterion number.
+    let risk_map: std::collections::HashMap<i32, &RiskAssessmentEntry> = evaluation
+        .risk_assessments
+        .iter()
+        .map(|r| (r.criterion_number, r))
+        .collect();
+
+    for criterion in &evaluation.criteria_assessments {
         let id = Uuid::now_v7();
+
+        // Derive risk level and score from the matching risk assessment entry,
+        // falling back to defaults for criteria rated "complete".
+        let (risk_level, score) = match risk_map.get(&criterion.number) {
+            Some(risk) => (
+                format_risk_level(&risk.risk_level.level),
+                risk.risk_level.score,
+            ),
+            None => ("Low".to_string(), 0.0),
+        };
+
         let model = risk_assessment_criteria::ActiveModel {
             id: Set(id),
             document_id: Set(document_id),
-            criterion: Set(criterion_name.clone()),
-            completeness: Set(result.completeness.clone()),
-            risk_level: Set(result.risk_level.clone()),
-            score: Set(result.score),
-            details: Set(result.details.clone()),
+            criterion: Set(criterion.name.clone()),
+            completeness: Set(criterion.rating.clone()),
+            risk_level: Set(risk_level),
+            score: Set(score),
+            details: Set(None),
+            what_documented: Set(Some(serde_json::to_value(&criterion.what_documented)
+                .map_err(|e| Error::Internal(format!("Failed to serialize what_documented: {e}")))?)),
+            gaps: Set(Some(serde_json::to_value(&criterion.gaps)
+                .map_err(|e| Error::Internal(format!("Failed to serialize gaps: {e}")))?)),
+            impact_description: Set(Some(criterion.impact.clone())),
+            recommendations: Set(Some(serde_json::to_value(&criterion.recommendations)
+                .map_err(|e| Error::Internal(format!("Failed to serialize recommendations: {e}")))?)),
         };
         model.insert(db).await?;
         ids.push(id);

--- a/modules/fundamental/src/risk_assessment/service/document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/document_processor.rs
@@ -152,13 +152,20 @@ pub async fn store_criteria_results(
             risk_level: Set(risk_level),
             score: Set(score),
             details: Set(None),
-            what_documented: Set(Some(serde_json::to_value(&criterion.what_documented)
-                .map_err(|e| Error::Internal(format!("Failed to serialize what_documented: {e}")))?)),
-            gaps: Set(Some(serde_json::to_value(&criterion.gaps)
-                .map_err(|e| Error::Internal(format!("Failed to serialize gaps: {e}")))?)),
+            what_documented: Set(Some(
+                serde_json::to_value(&criterion.what_documented).map_err(|e| {
+                    Error::Internal(format!("Failed to serialize what_documented: {e}"))
+                })?,
+            )),
+            gaps: Set(Some(serde_json::to_value(&criterion.gaps).map_err(
+                |e| Error::Internal(format!("Failed to serialize gaps: {e}")),
+            )?)),
             impact_description: Set(Some(criterion.impact.clone())),
-            recommendations: Set(Some(serde_json::to_value(&criterion.recommendations)
-                .map_err(|e| Error::Internal(format!("Failed to serialize recommendations: {e}")))?)),
+            recommendations: Set(Some(
+                serde_json::to_value(&criterion.recommendations).map_err(|e| {
+                    Error::Internal(format!("Failed to serialize recommendations: {e}"))
+                })?,
+            )),
         };
         model.insert(db).await?;
         ids.push(id);

--- a/modules/fundamental/src/risk_assessment/service/prompts/response_schema.json
+++ b/modules/fundamental/src/risk_assessment/service/prompts/response_schema.json
@@ -1,0 +1,364 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SAR Completeness Evaluation",
+  "description": "Structured output schema for Security Architecture Review completeness evaluation following NIST SP 800-30 methodology",
+  "type": "object",
+  "required": [
+    "criteria_assessments",
+    "risk_assessments",
+    "risk_prioritization"
+  ],
+  "properties": {
+    "criteria_assessments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "name",
+          "rating",
+          "what_documented",
+          "gaps",
+          "impact",
+          "recommendations"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string",
+            "description": "Criterion name (e.g., 'System Scope and Boundaries')"
+          },
+          "rating": {
+            "type": "string",
+            "enum": [
+              "complete",
+              "partial",
+              "missing"
+            ],
+            "description": "ONLY use these three values: complete (80-100% of expected elements), partial (30-79%), missing (<30%)"
+          },
+          "what_documented": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of what IS documented in the SAR"
+          },
+          "gaps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of what is MISSING or incomplete"
+          },
+          "impact": {
+            "type": "string",
+            "description": "Impact on NIST 800-30 system characterization"
+          },
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "action",
+                "priority"
+              ],
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "description": "Specific action to address gap"
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "critical",
+                    "high",
+                    "medium",
+                    "low"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "risk_assessments": {
+      "type": "array",
+      "description": "NIST 800-30 risk assessments for criteria rated partial or missing",
+      "items": {
+        "type": "object",
+        "required": [
+          "criterion_number",
+          "criterion_name",
+          "completeness_rating",
+          "threat_scenarios",
+          "likelihood",
+          "impact",
+          "risk_level"
+        ],
+        "properties": {
+          "criterion_number": {
+            "type": "integer"
+          },
+          "criterion_name": {
+            "type": "string"
+          },
+          "completeness_rating": {
+            "type": "string",
+            "enum": [
+              "partial",
+              "missing"
+            ]
+          },
+          "threat_scenarios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "threat_source",
+                "threat_event",
+                "vulnerability",
+                "attack_path"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "threat_source": {
+                  "type": "string",
+                  "description": "NIST taxonomy reference"
+                },
+                "threat_event": {
+                  "type": "string",
+                  "description": "NIST taxonomy reference"
+                },
+                "vulnerability": {
+                  "type": "string",
+                  "description": "What gap creates this vulnerability"
+                },
+                "attack_path": {
+                  "type": "string",
+                  "description": "Step-by-step attack sequence"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "likelihood": {
+            "type": "object",
+            "required": [
+              "score",
+              "level",
+              "rationale"
+            ],
+            "properties": {
+              "score": {
+                "type": "integer"
+              },
+              "level": {
+                "type": "string",
+                "enum": [
+                  "very_low",
+                  "low",
+                  "moderate",
+                  "high",
+                  "very_high"
+                ]
+              },
+              "rationale": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "impact": {
+            "type": "object",
+            "required": [
+              "score",
+              "level",
+              "rationale",
+              "domains"
+            ],
+            "properties": {
+              "score": {
+                "type": "integer"
+              },
+              "level": {
+                "type": "string",
+                "enum": [
+                  "very_low",
+                  "low",
+                  "moderate",
+                  "high",
+                  "very_high"
+                ]
+              },
+              "rationale": {
+                "type": "string",
+                "description": "Why this score, include financial estimates"
+              },
+              "domains": {
+                "type": "object",
+                "required": [
+                  "confidentiality",
+                  "integrity",
+                  "availability",
+                  "privacy",
+                  "safety"
+                ],
+                "properties": {
+                  "confidentiality": {
+                    "type": "integer"
+                  },
+                  "integrity": {
+                    "type": "integer"
+                  },
+                  "availability": {
+                    "type": "integer"
+                  },
+                  "privacy": {
+                    "type": "integer"
+                  },
+                  "safety": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "risk_level": {
+            "type": "object",
+            "required": [
+              "score",
+              "level",
+              "matrix_reference"
+            ],
+            "properties": {
+              "score": {
+                "type": "number",
+                "description": "(likelihood + impact) / 2"
+              },
+              "level": {
+                "type": "string",
+                "enum": [
+                  "very_low",
+                  "low",
+                  "moderate",
+                  "high",
+                  "very_high"
+                ]
+              },
+              "matrix_reference": {
+                "type": "string",
+                "description": "NIST Table 3-3 reference"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "risk_prioritization": {
+      "type": "object",
+      "required": [
+        "summary",
+        "critical_gaps",
+        "top_risks"
+      ],
+      "properties": {
+        "summary": {
+          "type": "object",
+          "required": [
+            "very_high_count",
+            "high_count",
+            "moderate_count",
+            "low_count",
+            "very_low_count"
+          ],
+          "properties": {
+            "very_high_count": {
+              "type": "integer"
+            },
+            "high_count": {
+              "type": "integer"
+            },
+            "moderate_count": {
+              "type": "integer"
+            },
+            "low_count": {
+              "type": "integer"
+            },
+            "very_low_count": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "critical_gaps": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "description": "Criterion numbers for critical gaps (Criteria 4, 5, 9)"
+        },
+        "top_risks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "rank",
+              "criterion_number",
+              "criterion_name",
+              "risk_score",
+              "risk_level",
+              "gap_summary",
+              "priority_action"
+            ],
+            "properties": {
+              "rank": {
+                "type": "integer"
+              },
+              "criterion_number": {
+                "type": "integer"
+              },
+              "criterion_name": {
+                "type": "string"
+              },
+              "risk_score": {
+                "type": "number"
+              },
+              "risk_level": {
+                "type": "string",
+                "enum": [
+                  "very_low",
+                  "low",
+                  "moderate",
+                  "high",
+                  "very_high"
+                ]
+              },
+              "gap_summary": {
+                "type": "string"
+              },
+              "priority_action": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
@@ -1,9 +1,9 @@
 use crate::risk_assessment::service::RiskAssessmentService;
 use crate::risk_assessment::service::document_processor::{
-    CriterionEvaluation, SarEvaluationResponse, store_criteria_results,
+    CriterionAssessment, Recommendation, RiskAssessmentEntry, RiskLevel, SarEvaluationResponse,
+    store_criteria_results,
 };
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement, TransactionTrait};
-use std::collections::HashMap;
 use test_context::test_context;
 use test_log::test;
 use trustify_test_context::TrustifyContext;
@@ -63,28 +63,44 @@ async fn test_store_criteria_results(ctx: &TrustifyContext) -> Result<(), anyhow
 
     let doc_uuid = uuid::Uuid::parse_str(&doc_id)?;
 
-    // Build a mock evaluation response
-    let mut criteria = HashMap::new();
-    criteria.insert(
-        "threat_identification".to_string(),
-        CriterionEvaluation {
-            completeness: "complete".to_string(),
-            risk_level: "low".to_string(),
-            score: 0.9,
-            details: Some(serde_json::json!({"summary": "Threats are well identified"})),
+    // Build a mock evaluation response using the new schema structure
+    let criteria_assessments = vec![
+        CriterionAssessment {
+            number: 1,
+            name: "Threat identification".to_string(),
+            rating: "complete".to_string(),
+            what_documented: vec!["Threats are well identified".to_string()],
+            gaps: vec![],
+            impact: "No significant impact".to_string(),
+            recommendations: vec![],
         },
-    );
-    criteria.insert(
-        "vulnerability_identification".to_string(),
-        CriterionEvaluation {
-            completeness: "partial".to_string(),
-            risk_level: "moderate".to_string(),
-            score: 0.6,
-            details: Some(serde_json::json!({"summary": "Some vulnerabilities missing"})),
+        CriterionAssessment {
+            number: 2,
+            name: "Vulnerability identification".to_string(),
+            rating: "partial".to_string(),
+            what_documented: vec!["Some vulnerabilities documented".to_string()],
+            gaps: vec!["Missing network vulnerability analysis".to_string()],
+            impact: "Moderate impact on risk characterization".to_string(),
+            recommendations: vec![Recommendation {
+                action: "Add network vulnerability scan results".to_string(),
+                priority: "high".to_string(),
+            }],
         },
-    );
+    ];
 
-    let evaluation = SarEvaluationResponse { criteria };
+    // Only partial/missing criteria get risk assessments
+    let risk_assessments = vec![RiskAssessmentEntry {
+        criterion_number: 2,
+        risk_level: RiskLevel {
+            score: 6.0,
+            level: "moderate".to_string(),
+        },
+    }];
+
+    let evaluation = SarEvaluationResponse {
+        criteria_assessments,
+        risk_assessments,
+    };
 
     // Store and verify
     let ids = store_criteria_results(doc_uuid, &evaluation, &tx).await?;
@@ -97,16 +113,27 @@ async fn test_store_criteria_results(ctx: &TrustifyContext) -> Result<(), anyhow
     assert_eq!(results.categories.len(), 1);
     assert_eq!(results.categories[0].criteria.len(), 2);
 
-    // Verify individual criterion values
+    // Verify complete criterion gets default low risk
     let threat = results.categories[0]
         .criteria
         .iter()
-        .find(|c| c.criterion == "threat_identification");
+        .find(|c| c.criterion == "Threat identification");
     assert!(threat.is_some());
     let threat = threat.unwrap();
     assert_eq!(threat.completeness, "complete");
-    assert_eq!(threat.risk_level, "low");
-    assert!((threat.score - 0.9).abs() < f64::EPSILON);
+    assert_eq!(threat.risk_level, "Low");
+    assert!((threat.score - 0.0).abs() < f64::EPSILON);
+
+    // Verify partial criterion gets risk from risk_assessments
+    let vuln = results.categories[0]
+        .criteria
+        .iter()
+        .find(|c| c.criterion == "Vulnerability identification");
+    assert!(vuln.is_some());
+    let vuln = vuln.unwrap();
+    assert_eq!(vuln.completeness, "partial");
+    assert_eq!(vuln.risk_level, "Moderate");
+    assert!((vuln.score - 6.0).abs() < f64::EPSILON);
 
     tx.rollback().await?;
     Ok(())


### PR DESCRIPTION
## Summary
- Updated `SarEvaluationResponse` and related structs to parse the new NIST 800-30 structured LLM response with `criteria_assessments` and `risk_assessments` arrays
- Added `what_documented`, `gaps`, `impact_description`, and `recommendations` columns to `risk_assessment_criteria` entity and migration for storing enriched evaluation data (stored in DB only, not exposed in API)
- Joined criteria with risk assessments by `criterion_number` to derive risk level and score; complete criteria default to low risk

Implements [JIRAPLAY-1422](https://redhat.atlassian.net/browse/JIRAPLAY-1422)

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo clippy` passes with strict flags
- [x] All 21 risk_assessment unit/integration tests pass
- [x] Updated `test_store_criteria_results` to validate new schema parsing, join logic, and default low risk for complete criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new LLM-backed risk assessment subsystem, including persistence, scoring, and HTTP APIs, integrated with existing storage, auth, and group concepts.

New Features:
- Add v2 risk assessment REST APIs to create, list, read, delete assessments, manage assessment documents, and retrieve scoring results.
- Introduce risk assessment domain models, services, and SeaORM entities for assessments, documents, and per-criterion evaluation data.
- Integrate LLM-based document processing for NIST 800-30 SAR evaluations, configurable via new TRUSTD_LLM_* environment variables, with structured scoring output.

Enhancements:
- Implement NIST 800-30–style scoring engine that aggregates per-category scores into an overall weighted risk level while tracking missing categories.
- Extend auth permissions to cover creating, reading, updating, and deleting risk assessments.
- Wire the new risk assessment module into the fundamental module’s endpoint configuration and shared storage backend.
- Document coding conventions and shared patterns such as duplicate-key handling for shared tables in a new CONVENTIONS.md file.

Build:
- Add fortified-llm-client, hex, tempfile, and temp-env dependencies needed for LLM-backed risk assessment processing.

CI:
- Allow CI and benchmark workflows to run on the NIST branch in addition to main and release branches.

Documentation:
- Document LLM configuration environment variables and project-wide coding conventions, including pre-commit workflow and shared database patterns.

Tests:
- Add integration and service tests for risk assessment CRUD operations, document upload/download, LLM configuration toggling, scoring, and criteria result persistence.