### PR TITLE
feat(risk-assessment): redesign PDF report with 5-section layout

### DIFF
--- a/entity/src/risk_assessment_document.rs
+++ b/entity/src/risk_assessment_document.rs
@@ -13,6 +13,8 @@ pub struct Model {
     pub processed: bool,
 
     pub uploaded_at: OffsetDateTime,
+
+    pub risk_prioritization: Option<serde_json::Value>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -56,6 +56,7 @@ mod m0002140_p2p_right_index;
 mod m0002150_fix_advisory_labels_index;
 mod m0002160_fix_ref_fk;
 mod m0002170_create_risk_assessment;
+mod m0002180_add_risk_prioritization;
 
 pub trait MigratorExt: Send {
     fn build_migrations() -> Migrations;
@@ -128,6 +129,7 @@ impl MigratorExt for Migrator {
             .normal(m0002150_fix_advisory_labels_index::Migration)
             .normal(m0002160_fix_ref_fk::Migration)
             .normal(m0002170_create_risk_assessment::Migration)
+            .normal(m0002180_add_risk_prioritization::Migration)
     }
 }
 

--- a/migration/src/m0002180_add_risk_prioritization.rs
+++ b/migration/src/m0002180_add_risk_prioritization.rs
@@ -1,0 +1,41 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RiskAssessmentDocument::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(RiskAssessmentDocument::RiskPrioritization).json_binary(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RiskAssessmentDocument::Table)
+                    .drop_column(RiskAssessmentDocument::RiskPrioritization)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum RiskAssessmentDocument {
+    Table,
+    RiskPrioritization,
+}

--- a/modules/fundamental/src/risk_assessment/service/document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/document_processor.rs
@@ -4,7 +4,7 @@ use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
-use trustify_entity::{risk_assessment_criteria, risk_assessment_document};
+use trustify_entity::risk_assessment_criteria;
 use uuid::Uuid;
 
 use super::llm_config::LlmConfig;
@@ -173,21 +173,4 @@ pub async fn store_criteria_results(
     }
 
     Ok(ids)
-}
-
-/// Update the risk_assessment_document record with the risk_prioritization JSON.
-pub async fn store_risk_prioritization(
-    document_id: Uuid,
-    risk_prioritization: Option<&Value>,
-    db: &impl ConnectionTrait,
-) -> Result<(), Error> {
-    if let Some(rp) = risk_prioritization {
-        let doc_update = risk_assessment_document::ActiveModel {
-            id: Set(document_id),
-            risk_prioritization: Set(Some(rp.clone())),
-            ..Default::default()
-        };
-        doc_update.update(db).await?;
-    }
-    Ok(())
 }

--- a/modules/fundamental/src/risk_assessment/service/document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/document_processor.rs
@@ -4,7 +4,7 @@ use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::Path;
-use trustify_entity::risk_assessment_criteria;
+use trustify_entity::{risk_assessment_criteria, risk_assessment_document};
 use uuid::Uuid;
 
 use super::llm_config::LlmConfig;
@@ -51,7 +51,8 @@ pub struct RiskAssessmentEntry {
 pub struct SarEvaluationResponse {
     pub criteria_assessments: Vec<CriterionAssessment>,
     pub risk_assessments: Vec<RiskAssessmentEntry>,
-    // risk_prioritization is present in the schema but not stored per-criterion.
+    /// Risk prioritization data from the LLM (summary, critical gaps, top risks).
+    pub risk_prioritization: Option<serde_json::Value>,
 }
 
 /// Extract text content from a PDF file.
@@ -172,4 +173,21 @@ pub async fn store_criteria_results(
     }
 
     Ok(ids)
+}
+
+/// Update the risk_assessment_document record with the risk_prioritization JSON.
+pub async fn store_risk_prioritization(
+    document_id: Uuid,
+    risk_prioritization: Option<&Value>,
+    db: &impl ConnectionTrait,
+) -> Result<(), Error> {
+    if let Some(rp) = risk_prioritization {
+        let doc_update = risk_assessment_document::ActiveModel {
+            id: Set(document_id),
+            risk_prioritization: Set(Some(rp.clone())),
+            ..Default::default()
+        };
+        doc_update.update(db).await?;
+    }
+    Ok(())
 }

--- a/modules/fundamental/src/risk_assessment/service/mod.rs
+++ b/modules/fundamental/src/risk_assessment/service/mod.rs
@@ -460,18 +460,11 @@ impl RiskAssessmentService {
         // Store criteria results
         let ids = document_processor::store_criteria_results(doc_uuid, &evaluation, db).await?;
 
-        // Store risk_prioritization on the document record
-        document_processor::store_risk_prioritization(
-            doc_uuid,
-            evaluation.risk_prioritization.as_ref(),
-            db,
-        )
-        .await?;
-
-        // Mark document as processed
+        // Mark document as processed and store risk_prioritization in a single update
         let doc_update = risk_assessment_document::ActiveModel {
             id: Set(doc_uuid),
             processed: Set(true),
+            risk_prioritization: Set(evaluation.risk_prioritization.clone()),
             ..Default::default()
         };
         doc_update.update(db).await?;

--- a/modules/fundamental/src/risk_assessment/service/mod.rs
+++ b/modules/fundamental/src/risk_assessment/service/mod.rs
@@ -175,6 +175,7 @@ impl RiskAssessmentService {
             source_document_id: Set(source_document_id),
             processed: Set(false),
             uploaded_at: Set(OffsetDateTime::now_utc()),
+            risk_prioritization: Set(None),
         };
 
         let result = db
@@ -319,12 +320,21 @@ impl RiskAssessmentService {
             .all(db)
             .await?;
 
+        // Collect risk_prioritization from the first document that has one
+        let mut risk_prioritization: Option<serde_json::Value> = None;
+
         // Build category results for scoring (using existing CriterionResult)
         let mut scoring_categories = Vec::with_capacity(documents.len());
         // Build report categories with enriched fields
         let mut report_categories = Vec::with_capacity(documents.len());
 
-        for doc in documents {
+        for doc in &documents {
+            if risk_prioritization.is_none()
+                && let Some(ref rp) = doc.risk_prioritization
+            {
+                risk_prioritization = Some(rp.clone());
+            }
+
             let criteria = risk_assessment_criteria::Entity::find()
                 .filter(risk_assessment_criteria::Column::DocumentId.eq(doc.id))
                 .all(db)
@@ -350,7 +360,7 @@ impl RiskAssessmentService {
 
             // Report needs enriched data
             report_categories.push(report_generator::ReportCategory {
-                category: doc.category,
+                category: doc.category.clone(),
                 criteria: criteria
                     .into_iter()
                     .map(|c| {
@@ -409,6 +419,7 @@ impl RiskAssessmentService {
                 .unwrap_or_else(|_| "N/A".to_string()),
             categories: report_categories,
             scoring: Some(scoring_result),
+            risk_prioritization,
         }))
     }
 
@@ -448,6 +459,14 @@ impl RiskAssessmentService {
 
         // Store criteria results
         let ids = document_processor::store_criteria_results(doc_uuid, &evaluation, db).await?;
+
+        // Store risk_prioritization on the document record
+        document_processor::store_risk_prioritization(
+            doc_uuid,
+            evaluation.risk_prioritization.as_ref(),
+            db,
+        )
+        .await?;
 
         // Mark document as processed
         let doc_update = risk_assessment_document::ActiveModel {

--- a/modules/fundamental/src/risk_assessment/service/report_generator.rs
+++ b/modules/fundamental/src/risk_assessment/service/report_generator.rs
@@ -17,6 +17,7 @@ pub struct ReportData {
     pub created_at: String,
     pub categories: Vec<ReportCategory>,
     pub scoring: Option<ScoringResult>,
+    pub risk_prioritization: Option<serde_json::Value>,
 }
 
 /// Per-category data including enriched criterion details.
@@ -305,183 +306,229 @@ fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
+/// Derive a rating label from a 0.0-1.0 score fraction.
+fn rating_label(score: f64) -> &'static str {
+    let pct = score * 100.0;
+    if pct >= 76.0 {
+        "Very High"
+    } else if pct >= 51.0 {
+        "High"
+    } else if pct >= 26.0 {
+        "Moderate"
+    } else {
+        "Low"
+    }
+}
+
 /// Generate a PDF report from assessment data.
+///
+/// The report contains five sections:
+///   1. Overall Rating
+///   2. Criteria Summary Table
+///   3. Risk Assessments (per-criterion)
+///   4. Risk Prioritization
+///   5. Criteria Assessments (detailed)
 pub fn generate_report(data: &ReportData) -> Result<Vec<u8>, anyhow::Error> {
-    let mut w = ReportWriter::new(&format!("Risk Assessment Report - {}", data.assessment_id))?;
+    let mut w = ReportWriter::new(&format!("SAR Completeness Report - {}", data.assessment_id))?;
 
-    // ── Page 1: Executive Summary ───────────────────────────────────────
+    let (complete, partial, missing) = count_completeness(&data.categories);
 
-    w.title("Risk Assessment Report");
+    // ── Section 1: Overall Rating ──────────────────────────────────────
+
+    w.title("SAR Completeness Report");
     w.spacing(2.0);
 
     w.key_value("Assessment ID:  ", &data.assessment_id);
     w.key_value("Group ID:  ", &data.group_id);
     w.key_value("Status:  ", &data.status);
     w.key_value("Date:  ", &data.created_at);
-
-    w.spacing(3.0);
-    w.horizontal_rule();
-
-    // Overall risk score
-    w.heading("Executive Summary");
+    w.spacing(2.0);
 
     if let Some(ref scoring) = data.scoring {
         let score_pct = scoring.overall.score * 100.0;
-        w.key_value("Overall Risk Score:  ", &format!("{:.1}%", score_pct));
-        w.key_value("Risk Level:  ", &scoring.overall.risk_level);
+        w.key_value("Overall Score:  ", &format!("{:.1}%", score_pct));
+        w.small_text("Calculated by LLM");
+        w.spacing(1.0);
+        w.key_value("Rating:  ", rating_label(scoring.overall.score));
+        w.spacing(2.0);
 
-        if !scoring.overall.missing_categories.is_empty() {
-            w.spacing(2.0);
-            w.bold_line("Missing Categories:");
-            for cat in &scoring.overall.missing_categories {
-                w.bullet(cat);
-            }
-        }
-
-        // Summary of findings
-        w.spacing(3.0);
-        w.subheading("Summary of Findings");
-
-        let (complete, partial, missing) = count_completeness(&data.categories);
-        w.key_value("Complete criteria:  ", &complete.to_string());
-        w.key_value("Partial criteria:  ", &partial.to_string());
-        w.key_value("Missing criteria:  ", &missing.to_string());
-
-        // Category scores table
-        if !scoring.categories.is_empty() {
-            w.spacing(3.0);
-            w.subheading("Category Scores");
-
-            let col_widths = [40.0, 25.0, 20.0, 30.0, 25.0, 30.0];
-            w.table_row(
-                &[
-                    "Category", "Score", "Weight", "Weighted", "Risk", "Criteria",
-                ],
-                &col_widths,
-                true,
-            );
-            w.horizontal_rule();
-
-            for cat in &scoring.categories {
-                w.table_row(
-                    &[
-                        &cat.category,
-                        &format!("{:.1}%", cat.score * 100.0),
-                        &format!("{:.0}%", cat.weight * 100.0),
-                        &format!("{:.1}%", cat.weighted_score * 100.0),
-                        &cat.risk_level,
-                        &cat.criteria_count.to_string(),
-                    ],
-                    &col_widths,
-                    false,
-                );
-            }
-        }
-
-        // Risk prioritization: top risks
-        w.spacing(3.0);
-        w.subheading("Risk Prioritization");
-
-        let mut top_risks: Vec<(&str, f64, &str)> = Vec::new();
-        for cat in &data.categories {
-            for cr in &cat.criteria {
-                if cr.completeness != "complete" && cr.score > 0.0 {
-                    top_risks.push((&cr.criterion, cr.score, &cr.risk_level));
-                }
-            }
-        }
-        top_risks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-
-        if top_risks.is_empty() {
-            w.body("No elevated risks identified.");
-        } else {
-            let col_widths = [80.0, 25.0, 30.0];
-            w.table_row(&["Criterion", "Score", "Risk Level"], &col_widths, true);
-            w.horizontal_rule();
-            for (name, score, level) in top_risks.iter().take(10) {
-                w.table_row(
-                    &[name, &format!("{:.1}%", score * 100.0), level],
-                    &col_widths,
-                    false,
-                );
-            }
-        }
+        // Three-column counts
+        let col_widths = [50.0, 50.0, 50.0];
+        w.table_row(&["Complete", "Partial", "Missing"], &col_widths, true);
+        w.table_row(
+            &[
+                &complete.to_string(),
+                &partial.to_string(),
+                &missing.to_string(),
+            ],
+            &col_widths,
+            false,
+        );
     } else {
         w.body("No scoring data available.");
     }
 
-    // ── Page 2+: Criteria Assessment Details ────────────────────────────
+    w.spacing(3.0);
+    w.horizontal_rule();
 
-    w.new_page();
-    w.title("Criteria Assessment Details");
+    // ── Section 2: Criteria Summary Table ──────────────────────────────
+
+    w.heading("Criteria Summary");
     w.spacing(2.0);
 
+    let summary_col_widths = [8.0, 55.0, 28.0, 28.0, 20.0];
+    w.table_row(
+        &["#", "Criterion", "Completeness", "Risk Level", "Score"],
+        &summary_col_widths,
+        true,
+    );
+    w.horizontal_rule();
+
+    let mut criterion_number = 0usize;
     for cat in &data.categories {
-        w.heading(&format!("Category: {}", cat.category));
-
-        // Criteria overview table
-        let col_widths = [8.0, 62.0, 30.0, 30.0, 25.0];
-        w.table_row(
-            &["#", "Criterion", "Completeness", "Risk Level", "Score"],
-            &col_widths,
-            true,
-        );
-        w.horizontal_rule();
-
-        for (i, cr) in cat.criteria.iter().enumerate() {
+        w.bold_line(&format!("Category: {}", cat.category));
+        for cr in &cat.criteria {
+            criterion_number += 1;
             w.table_row(
                 &[
-                    &(i + 1).to_string(),
+                    &criterion_number.to_string(),
                     &cr.criterion,
                     &cr.completeness,
                     &cr.risk_level,
-                    &format!("{:.1}%", cr.score * 100.0),
+                    &format!("{:.1}", cr.score),
                 ],
-                &col_widths,
+                &summary_col_widths,
                 false,
             );
         }
+    }
 
-        w.spacing(3.0);
+    w.spacing(3.0);
+    w.horizontal_rule();
 
-        // Detailed breakdown for partial/missing criteria
+    // ── Section 3: Risk Assessments (per-criterion) ────────────────────
+
+    w.new_page();
+    w.heading("Risk Assessments");
+    w.spacing(2.0);
+
+    for cat in &data.categories {
         for cr in &cat.criteria {
             if cr.completeness == "complete" {
                 continue;
             }
 
-            w.subheading(&cr.criterion);
-            w.key_value("Completeness:  ", &cr.completeness);
-            w.key_value("Risk Level:  ", &cr.risk_level);
-            w.key_value("Score:  ", &format!("{:.1}%", cr.score * 100.0));
+            w.subheading(&format!(
+                "{} - {} | Risk: {} ({:.1})",
+                cr.criterion, cr.completeness, cr.risk_level, cr.score
+            ));
 
-            if !cr.what_documented.is_empty() {
-                w.spacing(1.0);
-                w.bold_line("What is documented:");
-                for item in &cr.what_documented {
-                    w.bullet(item);
+            // Extract from details JSON if available
+            if let Some(ref details) = cr.details {
+                // Matrix reference
+                if let Some(matrix_ref) = details
+                    .get("risk_level")
+                    .and_then(|rl| rl.get("matrix_reference"))
+                    .and_then(|v| v.as_str())
+                {
+                    w.key_value("Matrix Reference:  ", matrix_ref);
                 }
-            }
 
-            if !cr.gaps.is_empty() {
-                w.spacing(1.0);
-                w.bold_line("Gaps identified:");
-                for gap in &cr.gaps {
-                    w.bullet(gap);
+                // Likelihood
+                if let Some(likelihood) = details.get("likelihood") {
+                    let level = likelihood
+                        .get("level")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+                    let lscore = likelihood
+                        .get("score")
+                        .map(format_json_value)
+                        .unwrap_or_else(|| "N/A".to_string());
+                    let rationale = likelihood
+                        .get("rationale")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+
+                    w.bold_line("Likelihood:");
+                    w.key_value("  Level:  ", level);
+                    w.key_value("  Score:  ", &lscore);
+                    w.key_value("  Rationale:  ", rationale);
                 }
-            }
 
-            if let Some(ref impact) = cr.impact_description {
-                w.spacing(1.0);
-                w.bold_line("Impact:");
-                w.paragraph(impact);
-            }
+                // Impact
+                if let Some(impact) = details.get("impact") {
+                    let level = impact
+                        .get("level")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+                    let iscore = impact
+                        .get("score")
+                        .map(format_json_value)
+                        .unwrap_or_else(|| "N/A".to_string());
+                    let rationale = impact
+                        .get("rationale")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
 
-            if !cr.recommendations.is_empty() {
-                w.spacing(1.0);
-                w.bold_line("Recommendations:");
-                for rec in &cr.recommendations {
-                    w.bullet(&format!("[{}] {}", rec.priority, rec.action));
+                    w.bold_line("Impact:");
+                    w.key_value("  Level:  ", level);
+                    w.key_value("  Score:  ", &iscore);
+                    w.key_value("  Rationale:  ", rationale);
+
+                    // Impact Domains
+                    if let Some(domains) = impact.get("domains") {
+                        w.bold_line("  Impact Domains:");
+                        for domain_name in &[
+                            "availability",
+                            "confidentiality",
+                            "integrity",
+                            "privacy",
+                            "safety",
+                        ] {
+                            if let Some(val) = domains.get(*domain_name) {
+                                w.key_value(
+                                    &format!("    {}:  ", domain_name),
+                                    &format_json_value(val),
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Threat Scenarios
+                if let Some(scenarios) = details.get("threat_scenarios")
+                    && let Some(arr) = scenarios.as_array()
+                {
+                    w.spacing(1.0);
+                    w.bold_line("Threat Scenarios:");
+                    for scenario in arr {
+                        if let Some(obj) = scenario.as_object() {
+                            let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("N/A");
+                            let source = obj
+                                .get("threat_source")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("N/A");
+                            let event = obj
+                                .get("threat_event")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("N/A");
+                            let vuln = obj
+                                .get("vulnerability")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("N/A");
+                            let attack_path = obj
+                                .get("attack_path")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("N/A");
+
+                            w.bullet(&format!("Name: {name}"));
+                            w.body(&format!("      Source: {source}"));
+                            w.body(&format!("      Event: {event}"));
+                            w.body(&format!("      Vulnerability: {vuln}"));
+                            w.body(&format!("      Attack Path: {attack_path}"));
+                            w.spacing(1.0);
+                        }
+                    }
                 }
             }
 
@@ -490,54 +537,138 @@ pub fn generate_report(data: &ReportData) -> Result<Vec<u8>, anyhow::Error> {
         }
     }
 
-    // ── Final Page: Risk Assessment Matrix ──────────────────────────────
+    // ── Section 4: Risk Prioritization ─────────────────────────────────
 
     w.new_page();
-    w.title("Risk Assessment Matrix");
+    w.heading("Risk Prioritization");
     w.spacing(2.0);
 
-    w.small_text("Based on NIST 800-30 risk assessment methodology.");
+    if let Some(ref rp) = data.risk_prioritization {
+        // Risk Level Summary
+        if let Some(summary) = rp.get("summary") {
+            w.subheading("Risk Level Summary");
+            let levels = [
+                ("Very High", "very_high_count"),
+                ("High", "high_count"),
+                ("Moderate", "moderate_count"),
+                ("Low", "low_count"),
+                ("Very Low", "very_low_count"),
+            ];
+            for (label, key) in &levels {
+                let count = summary.get(*key).and_then(|v| v.as_i64()).unwrap_or(0);
+                w.key_value(&format!("  {}:  ", label), &count.to_string());
+            }
+            w.spacing(2.0);
+        }
+
+        // Critical Gaps
+        if let Some(gaps) = rp.get("critical_gaps")
+            && let Some(arr) = gaps.as_array()
+        {
+            w.subheading("Critical Gaps");
+            if arr.is_empty() {
+                w.body("No critical gaps identified.");
+            } else {
+                let numbers: Vec<String> = arr
+                    .iter()
+                    .filter_map(|v| v.as_i64().map(|n| format!("Criterion {n}")))
+                    .collect();
+                w.body(&numbers.join(", "));
+            }
+            w.spacing(2.0);
+        }
+
+        // Top Risks
+        if let Some(top_risks) = rp.get("top_risks")
+            && let Some(arr) = top_risks.as_array()
+        {
+            w.subheading("Top Risks");
+            for risk in arr {
+                if let Some(obj) = risk.as_object() {
+                    let rank = obj.get("rank").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let name = obj
+                        .get("criterion_name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+                    let level = obj
+                        .get("risk_level")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+                    let rscore = obj
+                        .get("risk_score")
+                        .map(format_json_value)
+                        .unwrap_or_else(|| "N/A".to_string());
+                    let gap = obj
+                        .get("gap_summary")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+                    let action = obj
+                        .get("priority_action")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("N/A");
+
+                    w.bold_line(&format!("#{rank}. {name}"));
+                    w.key_value("  Risk Level:  ", level);
+                    w.key_value("  Score:  ", &rscore);
+                    w.key_value("  Gap Summary:  ", gap);
+                    w.key_value("  Priority Action:  ", action);
+                    w.spacing(1.0);
+                }
+            }
+        }
+    } else {
+        w.body("No risk prioritization data available.");
+    }
+
     w.spacing(3.0);
+    w.horizontal_rule();
+
+    // ── Section 5: Criteria Assessments (detailed) ─────────────────────
+
+    w.new_page();
+    w.heading("Criteria Assessments");
+    w.spacing(2.0);
 
     for cat in &data.categories {
         for cr in &cat.criteria {
-            if cr.completeness == "complete" {
-                continue;
+            w.subheading(&format!("{} - {}", cr.criterion, cr.completeness));
+
+            if let Some(ref impact) = cr.impact_description {
+                w.bold_line("IMPACT:");
+                w.paragraph(impact);
+                w.spacing(1.0);
             }
 
-            // Extract risk details from the details JSON if available
-            if let Some(ref details) = cr.details {
-                w.subheading(&cr.criterion);
-
-                // Threat scenarios
-                if let Some(scenarios) = details.get("threat_scenarios")
-                    && let Some(arr) = scenarios.as_array()
-                {
-                    w.bold_line("Threat Scenarios:");
-                    for scenario in arr {
-                        if let Some(s) = scenario.as_str() {
-                            w.bullet(s);
-                        }
-                    }
+            if !cr.what_documented.is_empty() {
+                w.bold_line("WHAT'S DOCUMENTED:");
+                for item in &cr.what_documented {
+                    w.bullet(item);
                 }
-
-                // Likelihood and impact
-                if let Some(likelihood) = details.get("likelihood") {
-                    w.key_value("Likelihood:  ", &format_json_value(likelihood));
-                }
-                if let Some(impact) = details.get("impact") {
-                    w.key_value("Impact:  ", &format_json_value(impact));
-                }
-                if let Some(risk_level) = details.get("risk_level") {
-                    w.key_value("Risk Level:  ", &format_json_value(risk_level));
-                }
-
-                w.spacing(2.0);
+                w.spacing(1.0);
             }
+
+            if !cr.gaps.is_empty() {
+                w.bold_line("GAPS:");
+                for gap in &cr.gaps {
+                    w.bullet(gap);
+                }
+                w.spacing(1.0);
+            }
+
+            if !cr.recommendations.is_empty() {
+                w.bold_line("RECOMMENDATIONS:");
+                for rec in &cr.recommendations {
+                    w.bullet(&format!("[{}] {}", rec.priority.to_uppercase(), rec.action));
+                }
+                w.spacing(1.0);
+            }
+
+            w.horizontal_rule();
+            w.spacing(1.0);
         }
     }
 
-    // NIST reference
+    // NIST reference footer
     w.spacing(3.0);
     w.horizontal_rule();
     w.small_text("Risk levels follow NIST 800-30 classification:");

--- a/modules/fundamental/src/risk_assessment/service/scoring.rs
+++ b/modules/fundamental/src/risk_assessment/service/scoring.rs
@@ -43,28 +43,38 @@ fn compute_category_score(criteria_scores: &[f64]) -> f64 {
     sum / criteria_scores.len() as f64
 }
 
-/// Compute the weighted overall score from per-category scores.
-/// Only categories with actual data are included. Weights are re-normalized
-/// to account for missing categories.
-fn compute_weighted_score(category_scores: &HashMap<String, f64>) -> f64 {
-    let weights: HashMap<&str, f64> = CATEGORY_WEIGHTS.iter().copied().collect();
+/// Compute the completeness-based overall score from all criteria across categories.
+///
+/// The score is a fraction (0.0–1.0):
+///   (complete_count * 1.0 + partial_count * 0.5) / total_criteria
+///
+/// This replaces the previous weighted-average approach. Per-category
+/// `CategoryScore` values (weight, weighted_score) remain unchanged so
+/// downstream consumers still have per-category detail.
+fn compute_completeness_score(categories: &[CategoryResult]) -> f64 {
+    let mut complete = 0usize;
+    let mut partial = 0usize;
+    let mut total = 0usize;
 
-    let mut weighted_sum = 0.0;
-    let mut total_weight = 0.0;
-
-    for (category, &score) in category_scores {
-        let weight = weights.get(category.as_str()).copied().unwrap_or(0.0);
-        if weight > 0.0 {
-            weighted_sum += score * weight;
-            total_weight += weight;
+    for cat in categories {
+        if !cat.processed || cat.criteria.is_empty() {
+            continue;
+        }
+        for criterion in &cat.criteria {
+            total += 1;
+            match criterion.completeness.as_str() {
+                "complete" => complete += 1,
+                "partial" => partial += 1,
+                _ => {} // "missing" contributes 0
+            }
         }
     }
 
-    if total_weight > 0.0 {
-        weighted_sum / total_weight
-    } else {
-        0.0
+    if total == 0 {
+        return 0.0;
     }
+
+    (complete as f64 * 1.0 + partial as f64 * 0.5) / total as f64
 }
 
 /// Compute the full scoring result from category results.
@@ -73,7 +83,7 @@ pub fn compute_scoring_result(categories: &[CategoryResult]) -> ScoringResult {
     let weights: HashMap<&str, f64> = CATEGORY_WEIGHTS.iter().copied().collect();
 
     // Compute per-category scores from processed categories with criteria
-    let mut category_scores_map: HashMap<String, f64> = HashMap::new();
+    let mut present_categories: Vec<String> = Vec::new();
     let mut scored_categories: Vec<CategoryScore> = Vec::new();
 
     for cat in categories {
@@ -86,7 +96,7 @@ pub fn compute_scoring_result(categories: &[CategoryResult]) -> ScoringResult {
         let weight = weights.get(cat.category.as_str()).copied().unwrap_or(0.0);
         let weighted = avg_score * weight;
 
-        category_scores_map.insert(cat.category.clone(), avg_score);
+        present_categories.push(cat.category.clone());
 
         scored_categories.push(CategoryScore {
             category: cat.category.clone(),
@@ -99,16 +109,14 @@ pub fn compute_scoring_result(categories: &[CategoryResult]) -> ScoringResult {
     }
 
     // Identify missing categories
-    let present: std::collections::HashSet<&str> =
-        category_scores_map.keys().map(|s| s.as_str()).collect();
     let missing: Vec<String> = ALL_CATEGORIES
         .iter()
-        .filter(|c| !present.contains(**c))
+        .filter(|c| !present_categories.iter().any(|p| p == **c))
         .map(|c| c.to_string())
         .collect();
 
-    // Compute overall weighted score (re-normalized for available categories)
-    let overall = compute_weighted_score(&category_scores_map);
+    // Compute overall completeness-based score (0.0–1.0 fraction)
+    let overall = compute_completeness_score(categories);
 
     ScoringResult {
         overall: OverallScore {
@@ -125,15 +133,23 @@ mod tests {
     use super::*;
     use crate::risk_assessment::model::{CategoryResult, CriterionResult};
 
-    fn make_criterion(name: &str, score: f64) -> CriterionResult {
+    fn make_criterion_with_completeness(
+        name: &str,
+        score: f64,
+        completeness: &str,
+    ) -> CriterionResult {
         CriterionResult {
             id: "test-id".to_string(),
             criterion: name.to_string(),
-            completeness: "complete".to_string(),
+            completeness: completeness.to_string(),
             risk_level: classify_risk_level(score).to_string(),
             score,
             details: None,
         }
+    }
+
+    fn make_criterion(name: &str, score: f64) -> CriterionResult {
+        make_criterion_with_completeness(name, score, "complete")
     }
 
     fn make_category(name: &str, scores: &[f64]) -> CategoryResult {
@@ -149,53 +165,91 @@ mod tests {
         }
     }
 
+    fn make_category_with_completeness(
+        name: &str,
+        criteria: Vec<(&str, f64, &str)>,
+    ) -> CategoryResult {
+        CategoryResult {
+            category: name.to_string(),
+            document_id: "doc-id".to_string(),
+            processed: true,
+            criteria: criteria
+                .into_iter()
+                .enumerate()
+                .map(|(i, (completeness, score, _risk))| {
+                    make_criterion_with_completeness(&format!("criterion_{i}"), score, completeness)
+                })
+                .collect(),
+        }
+    }
+
     #[test]
-    fn test_weighted_score_all_categories() {
+    fn test_completeness_score_all_complete() {
+        // All criteria are "complete" (default from make_category)
+        // 9 criteria total, all complete
+        // Score = (9 * 1.0) / 9 = 1.0
         let categories = vec![
-            make_category("pt", &[0.8, 0.6]),       // avg = 0.7, weight = 0.30
-            make_category("vex", &[0.5]),           // avg = 0.5, weight = 0.20
-            make_category("sar", &[0.9, 0.7, 0.8]), // avg = 0.8, weight = 0.20
-            make_category("dast", &[0.4]),          // avg = 0.4, weight = 0.15
-            make_category("sast", &[0.6]),          // avg = 0.6, weight = 0.10
-            make_category("threat_model", &[0.3]),  // avg = 0.3, weight = 0.05
+            make_category("pt", &[0.8, 0.6]),       // 2 complete
+            make_category("vex", &[0.5]),           // 1 complete
+            make_category("sar", &[0.9, 0.7, 0.8]), // 3 complete
+            make_category("dast", &[0.4]),          // 1 complete
+            make_category("sast", &[0.6]),          // 1 complete
+            make_category("threat_model", &[0.3]),  // 1 complete
         ];
 
         let result = compute_scoring_result(&categories);
 
-        // All categories present, no re-normalization needed
-        // Expected: 0.7*0.30 + 0.5*0.20 + 0.8*0.20 + 0.4*0.15 + 0.6*0.10 + 0.3*0.05
-        //         = 0.21 + 0.10 + 0.16 + 0.06 + 0.06 + 0.015 = 0.605
-        let expected = 0.605;
+        // All 9 criteria are "complete": (9*1.0)/9 = 1.0
+        let expected = 1.0;
         assert!(
             (result.overall.score - expected).abs() < 1e-10,
             "Expected overall score {expected}, got {}",
             result.overall.score
         );
-        assert_eq!(result.overall.risk_level, "High");
+        assert_eq!(result.overall.risk_level, "Very High");
         assert!(result.overall.missing_categories.is_empty());
         assert_eq!(result.categories.len(), 6);
     }
 
     #[test]
-    fn test_weighted_score_missing_categories() {
-        // Only PT and SAR available
-        let categories = vec![
-            make_category("pt", &[0.8]),  // avg = 0.8, weight = 0.30
-            make_category("sar", &[0.6]), // avg = 0.6, weight = 0.20
-        ];
+    fn test_completeness_score_mixed() {
+        // 2 complete, 1 partial, 1 missing = (2*1.0 + 1*0.5) / 4 = 2.5/4 = 0.625
+        let categories = vec![make_category_with_completeness(
+            "sar",
+            vec![
+                ("complete", 0.0, "Low"),
+                ("complete", 0.0, "Low"),
+                ("partial", 0.5, "Moderate"),
+                ("missing", 0.8, "High"),
+            ],
+        )];
 
         let result = compute_scoring_result(&categories);
 
-        // Re-normalized: total available weight = 0.30 + 0.20 = 0.50
-        // Weighted sum = 0.8*0.30 + 0.6*0.20 = 0.24 + 0.12 = 0.36
-        // Re-normalized overall = 0.36 / 0.50 = 0.72
-        let expected = 0.72;
+        let expected = 0.625;
         assert!(
             (result.overall.score - expected).abs() < 1e-10,
             "Expected overall score {expected}, got {}",
             result.overall.score
         );
         assert_eq!(result.overall.risk_level, "High");
+    }
+
+    #[test]
+    fn test_completeness_score_missing_categories() {
+        // Only PT and SAR available, both all complete
+        // 2 criteria total, both complete: (2*1.0)/2 = 1.0
+        let categories = vec![make_category("pt", &[0.8]), make_category("sar", &[0.6])];
+
+        let result = compute_scoring_result(&categories);
+
+        let expected = 1.0;
+        assert!(
+            (result.overall.score - expected).abs() < 1e-10,
+            "Expected overall score {expected}, got {}",
+            result.overall.score
+        );
+        assert_eq!(result.overall.risk_level, "Very High");
         assert_eq!(result.overall.missing_categories.len(), 4);
         assert!(
             result
@@ -225,19 +279,19 @@ mod tests {
 
     #[test]
     fn test_risk_level_boundaries() {
-        // Low: 0–25%
+        // Low: 0-25%
         assert_eq!(classify_risk_level(0.0), "Low");
         assert_eq!(classify_risk_level(0.25), "Low");
 
-        // Moderate: 26–50%
+        // Moderate: 26-50%
         assert_eq!(classify_risk_level(0.26), "Moderate");
         assert_eq!(classify_risk_level(0.50), "Moderate");
 
-        // High: 51–75%
+        // High: 51-75%
         assert_eq!(classify_risk_level(0.51), "High");
         assert_eq!(classify_risk_level(0.75), "High");
 
-        // Very High: 76–100%
+        // Very High: 76-100%
         assert_eq!(classify_risk_level(0.76), "Very High");
         assert_eq!(classify_risk_level(1.0), "Very High");
     }
@@ -274,5 +328,46 @@ mod tests {
                 .missing_categories
                 .contains(&"sar".to_string())
         );
+        // 1 complete criterion: (1*1.0)/1 = 1.0
+        assert!(
+            (result.overall.score - 1.0).abs() < 1e-10,
+            "Expected overall score 1.0, got {}",
+            result.overall.score
+        );
+    }
+
+    #[test]
+    fn test_completeness_score_all_missing() {
+        // All criteria are "missing"
+        let categories = vec![make_category_with_completeness(
+            "sar",
+            vec![("missing", 0.9, "Very High"), ("missing", 0.7, "High")],
+        )];
+
+        let result = compute_scoring_result(&categories);
+
+        // (0*1.0 + 0*0.5) / 2 = 0.0
+        assert!((result.overall.score).abs() < f64::EPSILON);
+        assert_eq!(result.overall.risk_level, "Low");
+    }
+
+    #[test]
+    fn test_completeness_score_all_partial() {
+        // All criteria are "partial"
+        let categories = vec![make_category_with_completeness(
+            "sar",
+            vec![("partial", 0.5, "Moderate"), ("partial", 0.6, "High")],
+        )];
+
+        let result = compute_scoring_result(&categories);
+
+        // (0*1.0 + 2*0.5) / 2 = 0.5
+        let expected = 0.5;
+        assert!(
+            (result.overall.score - expected).abs() < 1e-10,
+            "Expected overall score {expected}, got {}",
+            result.overall.score
+        );
+        assert_eq!(result.overall.risk_level, "Moderate");
     }
 }

--- a/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
+++ b/modules/fundamental/src/risk_assessment/service/test_document_processor.rs
@@ -100,6 +100,7 @@ async fn test_store_criteria_results(ctx: &TrustifyContext) -> Result<(), anyhow
     let evaluation = SarEvaluationResponse {
         criteria_assessments,
         risk_assessments,
+        risk_prioritization: None,
     };
 
     // Store and verify


### PR DESCRIPTION
## Summary

- Redesign PDF report to match SAR Completeness Report Viewer reference with 5 sections: Overall Rating, Criteria Summary, Risk Assessments, Risk Prioritization, Criteria Assessments
- Replace weighted NIST score with completeness-based formula: `(complete * 1.0 + partial * 0.5) / total`
- Add `risk_prioritization` JSONB column to `risk_assessment_document` via migration
- Store LLM risk_prioritization (critical gaps, top risks) during document processing

Implements [JIRAPLAY-1432](https://redhat.atlassian.net/browse/JIRAPLAY-1432)

## Test plan

- [ ] `cargo test -p trustify-module-fundamental -- scoring` — scoring tests pass with new formula
- [ ] `cargo build` — compiles
- [ ] Manual test: upload SAR document, call `/v2/risk-assessment/{id}/report`, verify PDF contains all 5 sections
- [ ] Verify UI shows same overall score as PDF report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign the SAR completeness PDF report into a five-section layout, switch the overall score to a completeness-based formula, and persist LLM-provided risk prioritization data on risk assessment documents for use in reports.

New Features:
- Introduce a five-section SAR Completeness PDF report including overall rating, criteria summary, risk assessments, risk prioritization, and detailed criteria assessments.
- Persist LLM-generated risk prioritization data on risk assessment documents and surface it in the PDF report.

Enhancements:
- Replace the weighted per-category overall score with a completeness-based scoring formula using complete and partial criteria counts.
- Enrich risk assessment and criteria sections in the PDF with structured likelihood, impact, threat scenarios, and recommendations extracted from details JSON.

Tests:
- Expand scoring unit tests to cover the new completeness-based overall score across mixed, missing, complete, and partial criteria scenarios.