### PR TITLE
docs: document migration reversibility requirement in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -159,6 +159,7 @@ Any files modified by steps 1–2 (e.g., `openapi.yaml`, JSON schema files) must
 - Column additions use `add_column_if_not_exists()`
 - Drop operations use `.if_exists()`
 - Raw SQL loaded via `include_str!("migration_dir/up.sql")`
+- Migrations must implement `down()` for reversibility — the `test_migrations` CI test verifies this by running `refresh()` (down + up) on every migration
 - Data migrations are separate from schema migrations, run via `trustd db data <names>`
 
 ## Rust Idioms
@@ -926,7 +927,8 @@ idempotency guards, raw SQL loading, data migration separation). Additional conv
 
 - **Numbering**: increment by 10 (e.g., `m0002190` → `m0002200`) to leave room for
   insertions.
-- **Reversibility**: implement both `up()` and `down()`.
+- **Reversibility**: implement both `up()` and `down()`. The `test_migrations` CI test
+  runs `refresh()` (down + up) on every migration to enforce this.
 - **Schema vs. data**: schema migrations registered with `.normal()`; data backfills
   registered with `.data()`. Prefer no data in schema migrations — separate schema changes
   from data changes.


### PR DESCRIPTION
## Summary

- Add explicit convention that migrations must implement `down()` for reversibility
- Reference the `test_migrations` CI check that enforces this by running `refresh()` (down + up)
- Update both the main Migration Patterns section and the Database Resource Conventions > Migrations sub-section

Implements [TC-4512](https://redhat.atlassian.net/browse/TC-4512)

## Test plan

- [ ] Verify CONVENTIONS.md renders correctly on GitHub
- [ ] Confirm both sections reference `test_migrations` and `refresh()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Clarify that all migrations must implement a down() function for reversibility and reference the test_migrations CI check that runs refresh() (down + up) on each migration in both the Migration Patterns and Database Resource Conventions sections.